### PR TITLE
Add hostname from Host header to http log

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -77,6 +77,7 @@ end
 frontend http-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:80
+    capture request header Host len 256
     default_backend http-routers
 <%
 if_p("ha_proxy.headers") do |headers|
@@ -137,6 +138,7 @@ frontend https-in
     <% if p("ha_proxy.hsts_enable") %>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
     <% end %>
+    capture request header Host len 256
     default_backend http-routers
 <%
 if_p("ha_proxy.headers") do |headers|


### PR DESCRIPTION
This change adds the first 20 characters of the 'Host' header to the log. It helps when you try to find out to which applications the requests are sent.

A shortened example of a line in the logfile. The captured host name is highlighted:

Jun 28 14:26:15 localhost haproxy[4812]: 52.52.52.52:1337 [28/Jun/2017:14:25:45.357] https-in~ http-routers/node0 30008/0/0/7/30015 200 1442 - - ---- 3/3/2/2/0 0/0 **{api.cf.cf-hcp-wot.aw}** "GET /internal/bulk/apps?batch_size=500&format=fingerprint&token={} HTTP/1.1" 