### PR TITLE
Add option to set number of haproxy threads per VM

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -111,10 +111,10 @@ properties:
     default:     30
 
   ha_proxy.stats_enable:
-    description: "If true, haproxy will enable a socket for stats. You can see the stats on haproxy_ip:9000/haproxy_stats"
+    description: "If true, haproxy will enable a socket for stats. You can see the stats on `haproxy_ip:9000/haproxy_stats`. If multithreading is enabled (`ha_proxy.threads > 1`) haproxy will create a separate socket and stat page for each thread. Each stat page is reachable on a different port ranging from `9000` to `9000 + ha_proxy.threads - 1`."
     default: false
   ha_proxy.stats_bind:
-    description: "Define one or several listening addresses and/or ports in a frontend."
+    description: "Define listening address and port for the stats frontend. If multithreading is enabled (`ha_proxy.threads > 1`) multiple stat pages are available - one for each thread. You can see the stat page for each thread on a separate port - starting at the defined port number."
     default: "*:9000"
   ha_proxy.stats_user:
     description: "User name to authenticate haproxy stats"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -28,6 +28,9 @@ consumes:
     optional: true
 
 properties:
+  ha_proxy.threads:
+    description: "Optional number of threads per VM"
+    default: 1
   ha_proxy.syslog_server:
     description: "An IPv4 address optionally followed by a colon and a UDP port. It can also be an IPv6 address or filesystem path to a UNIX domain socket."
     default: "127.0.0.1"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -3,14 +3,22 @@
 global
     log <%= p('ha_proxy.syslog_server') %> syslog <%= p('ha_proxy.log_level') %>
     daemon
+    <% if p("ha_proxy.threads") > 1 %>
+    nbproc <%= p("ha_proxy.threads") %>
+    <% end %>
     user vcap
     group vcap
     maxconn 64000
     spread-checks 4
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
+    <% if p("ha_proxy.threads") > 1 %>
+      <% 1.upto(p("ha_proxy.threads")) do |proc| %>
+    stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 level admin process <%= proc%>
+      <% end %>
+    <% else %>
     stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
+    <% end %>
     stats timeout 2m
-
 <%
     ssl_flags = "no-sslv3"
     if p("ha_proxy.disable_tls_10")
@@ -44,16 +52,23 @@ defaults
     timeout queue           <%= (p("ha_proxy.queue_timeout").to_f      * 1000).to_i %>ms
 
 <% if p("ha_proxy.stats_enable") %>
-listen stats
-    bind <%= p("ha_proxy.stats_bind") %>
+  <% stat = p("ha_proxy.stats_bind").split(':');
+     stat_prefix = stat[0] + ":";
+     stat_port = stat[1].to_i;
+   %>
+  <% 1.upto(p("ha_proxy.threads")) do |proc| %>
+listen stats_<%= proc %>
+    bind <%= stat_prefix %><%= stat_port + (proc - 1) %>
+    bind-process <%= proc %>
     acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
     http-request deny unless private
     mode http
     stats enable
     stats hide-version
-    stats realm Haproxy\ Statistics
+    stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
+  <% end %>
 <% end %>
 
 <%# HTTP Frontend %>


### PR DESCRIPTION
This optional parameter allows to set the number of haproxy threads started for each VM. This option helps to improve the performance - especially on multicore VMs.