### PR TITLE
Add black- and whitelisting for http(s) access

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -17,6 +17,8 @@ templates:
   helpers/ctl_setup.sh:      helpers/ctl_setup.sh
   helpers/ctl_utils.sh:      helpers/ctl_utils.sh
   properties.sh.erb:         data/properties.sh
+  blacklist_cidrs.txt.erb:   config/blacklist_cidrs.txt
+  whitelist_cidrs.txt.erb:   config/whitelist_cidrs.txt
 
 consumes:
   - name: http_backend
@@ -197,3 +199,21 @@ properties:
   ha_proxy.binding_ip:
     description: "If there are multiple ethernet interfaces, specify which one to bind"
     default: ""
+
+  ha_proxy.cidr_blacklist:
+    description: "List of CIDRs to block for http(s). Format is string array of CIDRs or single string of base64 encoded gzip."
+    default: ~
+    example:
+      cidr_blacklist:
+      - 10.0.0.0/8
+      - 192.168.2.0/24
+  ha_proxy.cidr_whitelist:
+    description: "List of CIDRs to allow for http(s). Format is string array of CIDRs or single string of base64 encoded gzip."
+    default: ~
+    example:
+      cidr_whitelist:
+      - 172.168.4.1/32
+      - 10.2.0.0/16
+  ha_proxy.block_all:
+    description: "Optionally block all incoming traffic to http(s). Use in conjunction with whitelist."
+    default: false

--- a/jobs/haproxy/templates/blacklist_cidrs.txt.erb
+++ b/jobs/haproxy/templates/blacklist_cidrs.txt.erb
@@ -1,0 +1,25 @@
+# generated from blacklist_cidrs.txt.erb
+<%
+require "base64"
+require 'zlib'
+require 'stringio'
+
+if_p("ha_proxy.cidr_blacklist") do |cidrs|
+  uncompressed = ''
+  if cidrs.is_a?(Array) then
+    uncompressed << "\# detected cidrs provided as array in cleartext format\n"
+    cidrs.each do |cidr|
+      uncompressed << cidr << "\n"
+    end
+  else
+    gzplain = Base64.decode64(cidrs)
+    gz = Zlib::GzipReader.new(StringIO.new(gzplain))
+    uncompressed = gz.read
+  end
+%>
+# BEGIN blacklist cidrs
+<%= uncompressed %>
+# END blacklist cidrs
+<%
+end
+%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -77,6 +77,18 @@ end
 frontend http-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:80
+    <% if_p("ha_proxy.cidr_whitelist") do %>
+    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
+    tcp-request content accept if whitelist
+    <% end %>
+    <% if_p("ha_proxy.cidr_blacklist") do %>
+    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
+    tcp-request content reject if blacklist
+    <% end %>
+    <% if p("ha_proxy.block_all") then %>
+    tcp-request content reject
+    <% end %>
+
     capture request header Host len 256
     default_backend http-routers
 <%
@@ -135,6 +147,18 @@ frontend https-in
     <% else %>
     bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl
     <% end %>
+    <% if_p("ha_proxy.cidr_whitelist") do %>
+    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
+    tcp-request content accept if whitelist
+    <% end %>
+    <% if_p("ha_proxy.cidr_blacklist") do %>
+    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
+    tcp-request content reject if blacklist
+    <% end %>
+    <% if p("ha_proxy.block_all") then %>
+    tcp-request content reject
+    <% end %>
+
     <% if p("ha_proxy.hsts_enable") %>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
     <% end %>

--- a/jobs/haproxy/templates/whitelist_cidrs.txt.erb
+++ b/jobs/haproxy/templates/whitelist_cidrs.txt.erb
@@ -1,0 +1,25 @@
+# generated from whitelist_cidrs.txt.erb
+<%
+require "base64"
+require 'zlib'
+require 'stringio'
+
+if_p("ha_proxy.cidr_whitelist") do |cidrs|
+  uncompressed = ''
+  if cidrs.is_a?(Array) then
+    uncompressed << "\# detected cidrs provided as array in cleartext format\n"
+    cidrs.each do |cidr|
+      uncompressed << cidr << "\n"
+    end
+  else
+    gzplain = Base64.decode64(cidrs)
+    gz = Zlib::GzipReader.new(StringIO.new(gzplain))
+    uncompressed = gz.read
+  end
+%>
+# BEGIN whitelist cidrs
+<%= uncompressed %>
+# END whitelist cidrs
+<%
+end
+%>


### PR DESCRIPTION
This pull request adds the feature to optionally provide a black- and whitelist for http(s) access.

The black- and whitelist each contain a list of CIDRs. A client is allowed to connect to http(s) if
- the IP is whitelisted **OR**
- the IP not blacklisted

You can provide the lists in two formats.
- as an inline yaml array. See: example in the spec file.
- as a gzipped and base64 encoded string (large files). See: [HAProxy - load patterns from a file '-f'](https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#7.1) for details about the file format. 

The tcp connection is dropped at `content reject` rather then `connection reject` because the client ip is not available in the latter case if accept-proxy is used. See [HAProxy accept-proxy](https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#5.1-accept-proxy). Hence blocked clients will see an empty response rather then a connection reject:
```
$ curl https://my.site.com
curl: (52) Empty reply from server
```