### PR TITLE
Add option to specify balance algorithm

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -179,6 +179,7 @@ properties:
           backend_servers: # required - list of backend IPs to connect to
           - 10.20.10.10
           - 10.20.10.11
+          balance: roundrobin # optional - sets algorithm used to select a server when doing load balancing
           backend_port: 80 # optional - sets backend port - otherwise defaults to `port`
           ssl: true        # optional - enables ssl, and uses the `ha_proxy.ssl_pem` provided key
           backend_ssl: "verify"  # optional - enables ssl backend, one of `verify`, `noverify`, any other value assumes no ssl backend.

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -340,6 +340,10 @@ end %>
 
 backend tcp-<%= tcp_proxy["name"] %>
     mode tcp
+<% if tcp_proxy["balance"] %>
+    balance <%= tcp_proxy["balance"] %>
+<% end %>
+
 <%
 backend_port = tcp_proxy["port"]
 if tcp_proxy["backend_port"]


### PR DESCRIPTION
The pull request adds the option to specify the load balancing algorithm for tcp backends. For example, this allows us to use leastconn algorithm for longer running sessions (such as SSH).