### PR TITLE
Add option to specify buffer size

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -39,6 +39,9 @@ properties:
   ha_proxy.log_level:
     description: "Log level"
     default: "info"
+  ha_proxy.buffer_size_bytes:
+    description: "Buffer size to use for requests, any requests larger than this (large cookies or query strings) will result in a gateway error"
+    default: 16384
   ha_proxy.internal_only_domains:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -11,6 +11,7 @@ global
     maxconn 64000
     spread-checks 4
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
+    tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
     <% if p("ha_proxy.threads") > 1 %>
       <% 1.upto(p("ha_proxy.threads")) do |proc| %>
     stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 level admin process <%= proc%>


### PR DESCRIPTION
This pull request adds the option to specify the buffer size to use for requests. The option enables increasing the buffer size to allow applications that require large cookies or query strings to function.