### PR TITLE
Add option to enable http health check on port 8080

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -54,7 +54,7 @@ properties:
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
   ha_proxy.enable_health_check_http:
-    description: "Optionally enable http health-check on `haproxy_ip:8080/health`"
+    description: "Optionally enable http health-check on `haproxy_ip:8080/health`. It shows `200 OK` if >0 backend servers are up."
     default: false
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"
@@ -192,6 +192,8 @@ properties:
                                  # Setting `verify` requires `ha_proxy.backend_ca_file` key to be set.
           backend_verifyhost: example.com # optional - hostname to verify in the x509 certificate subject for SSL-enabled backend servers
                                           # only used if backend_ssl: `verify` is set
+          health_check_http: 4444 # optional port number - if provided a heath check http site is created at `haproxy_ip:4444/health`.
+                                  # It shows `200 OK` if >0 backend servers are up.
   ha_proxy.tcp_link_port:
     description: "Port haproxy should listen on when using the tcp_backend link"
   ha_proxy.resolvers:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -53,6 +53,9 @@ properties:
     default: ~
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
+  ha_proxy.enable_health_check_http:
+    description: "Optionally enable http health-check on `haproxy_ip:8080/health`"
+    default: false
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"
     default: false

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -360,7 +360,7 @@ if tcp_proxy["backend_port"]
   backend_port = tcp_proxy["backend_port"]
 end %>
 
-<% tcp_proxy["backend_servers"].each_with_index do |ip, index| %>
+  <% tcp_proxy["backend_servers"].each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
         resolvers default <% end -%> check inter 1000  <% if tcp_proxy["backend_ssl"] then -%>
            <% if tcp_proxy["backend_ssl"].downcase == "verify" then -%>
@@ -369,6 +369,14 @@ end %>
            <% elsif tcp_proxy["backend_ssl"].downcase == "noverify" then -%>
              ssl verify none <% end -%>
         <% end -%>
-     <% end -%>
+  <% end -%>
 
+  <% if tcp_proxy["health_check_http"] then %>
+listen health_check_http_tcp-<%= tcp_proxy["name"] %>
+    bind :<%= tcp_proxy["health_check_http"] %>
+    mode http
+    monitor-uri /health
+    acl tcp-<%= tcp_proxy["name"] %>-routers_down nbsrv(tcp-<%= tcp_proxy["name"] %>) eq 0
+    monitor fail if tcp-<%= tcp_proxy["name"] %>-routers_down
+  <% end -%>
 <% end -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -72,6 +72,15 @@ listen stats_<%= proc %>
   <% end %>
 <% end %>
 
+<% if p("ha_proxy.enable_health_check_http") %>
+listen health_check_http_url
+    bind :8080
+    mode http
+    monitor-uri /health
+    acl http-routers_down nbsrv(http-routers) eq 0
+    monitor fail if http-routers_down
+<% end %>
+
 <%# HTTP Frontend %>
 
 <%


### PR DESCRIPTION
The pull request adds the option to enable http health check on `haproxy_ip:8080/health`. The health check monitors the status of the http-routers. A failure is reported when all http-routers are down.