### PR TITLE
Update ssl_pem to support hash of cert_chain/private_key

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -49,7 +49,26 @@ properties:
     description: "Space separated trusted cidr blocks for internal_only_domains"
     default: 0.0.0.0/32
   ha_proxy.ssl_pem:
-    description: "SSL certificate (PEM file), or an array of SSL certificates (PEM files)"
+    description: |
+      Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'cert_chain' and 'private_key',
+      each of which supports a PEM block. Each element can also be a single string containing the cert chain and the private key.
+    example:
+      tls_pem:
+      - cert_chain: |
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+        private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          -----END RSA PRIVATE KEY-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+        -----BEGIN RSA PRIVATE KEY-----
+        -----END RSA PRIVATE KEY-----
     default: ~
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -5,9 +5,13 @@ if_p("ha_proxy.ssl_pem") do |pem|
   end
 
   pem.each_with_index do |cert, i|
+    pem_block = cert
+    if cert.is_a?(Hash)
+      pem_block = cert['cert_chain'] + cert['private_key']
+    end
 %>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
-<%= cert %>
+<%= pem_block %>
 <%
   end
 end


### PR DESCRIPTION
Supported formats are:
- Single string cert(s) + private key
- Single hash entry, cert_chain + private_key
- Array of strings, cert(s) + private_key
- Array of hash objects, cert_chain + private_key
- Mixed Array of strings and hash objects

[#150282438]

Signed-off-by: Edwin Xie <exie@pivotal.io>