### PR TITLE
Add support for http health check when using tcp_backend link

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -215,6 +215,8 @@ properties:
                                   # It shows `200 OK` if >0 backend servers are up.
   ha_proxy.tcp_link_port:
     description: "Port haproxy should listen on when using the tcp_backend link"
+  ha_proxy.tcp_link_health_check_http:
+    description: "Optional port for http health check when using the tcp_backend link."
   ha_proxy.resolvers:
     description: "List of DNS servers"
     example:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -331,7 +331,8 @@ if_link("tcp_backend") do |tcp_backend|
     "name" => tcp_backend.instances.first.name || "link",
     "backend_servers" => tcp_backend.instances.map(&:address),
     "port" => tcp_backend.p("port", p("ha_proxy.tcp_link_port")),
-    "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port"))
+    "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port")),
+    "health_check_http" => tcp_backend.p("health_check_http", p("ha_proxy.tcp_link_health_check_http", nil))
   }
 end %>
 <% tcp.each do |tcp_proxy| %>


### PR DESCRIPTION
The http health check for tcp backends can only be used for backends specified in the manifest, but not for dynamically linked backends: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/blob/master/jobs/haproxy/templates/haproxy.config.erb#L374-L381

With this PR a link can either contain a `health_check_http` property or the (optional) global property `ha_proxy.tcp_link_health_check_http` is used.
