### PR TITLE
This is a commit to let haproxy to do mutual ssl

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -8,18 +8,20 @@ packages:
 - ttar
 
 templates:
-  haproxy.config.erb:        config/haproxy.config
-  haproxy_ctl:               bin/haproxy_ctl
-  monit_debugger:            bin/monit_debugger
-  certs.ttar.erb:            config/certs.ttar
-  ssl_redirect.map.erb:      config/ssl_redirect.map
-  backend-ca-certs.erb:      config/backend-ca-certs.pem
-  backend-crt.erb:           config/backend-crt.pem
-  helpers/ctl_setup.sh:      helpers/ctl_setup.sh
-  helpers/ctl_utils.sh:      helpers/ctl_utils.sh
-  properties.sh.erb:         data/properties.sh
-  blacklist_cidrs.txt.erb:   config/blacklist_cidrs.txt
-  whitelist_cidrs.txt.erb:   config/whitelist_cidrs.txt
+  haproxy.config.erb:         config/haproxy.config
+  haproxy_ctl:                bin/haproxy_ctl
+  monit_debugger:             bin/monit_debugger
+  certs.ttar.erb:             config/certs.ttar
+  ssl_redirect.map.erb:       config/ssl_redirect.map
+  backend-ca-certs.erb:       config/backend-ca-certs.pem
+  client-ca-certs.erb:        config/client-ca-certs.pem
+  backend-crt.erb:            config/backend-crt.pem
+  client-revocation-list.erb: config/client-revocation-list.pem
+  helpers/ctl_setup.sh:       helpers/ctl_setup.sh
+  helpers/ctl_utils.sh:       helpers/ctl_utils.sh
+  properties.sh.erb:          data/properties.sh
+  blacklist_cidrs.txt.erb:    config/blacklist_cidrs.txt
+  whitelist_cidrs.txt.erb:    config/whitelist_cidrs.txt
 
 consumes:
   - name: http_backend
@@ -204,6 +206,26 @@ properties:
       -----BEGIN PRIVATE KEY-----
       ******
       -----END PRIVATE KEY-----
+  ha_proxy.client_cert:
+    description: "Enable haproxy mutual auth and produce a client cert header (X-Forwarded-Client-Cert) to offload mutual ssl client certificate to backend"
+    default: false
+
+  ha_proxy.client_ca_file:
+    description: "path for CA certs to validate client certificate"
+    example: |
+      -----BEGIN CERTIFICATE-----
+      ******
+      -----END CERTIFICATE-----
+      -----BEGIN PRIVATE KEY-----
+      ******
+      -----END PRIVATE KEY-----
+
+  ha_proxy.client_cert_ignore_err:
+    description: "error code of client cert to ignore during mutual ssl handshake"
+    example: all|1
+
+  ha_proxy.client_revocation_list:
+    description: "provide a list of revocation certs"
 
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"

--- a/jobs/haproxy/templates/client-ca-certs.erb
+++ b/jobs/haproxy/templates/client-ca-certs.erb
@@ -1,0 +1,7 @@
+<%
+if_p("ha_proxy.client_ca_file") do |pem|
+%>
+<%= pem %>
+<%
+end
+%>

--- a/jobs/haproxy/templates/client-revocation-list.erb
+++ b/jobs/haproxy/templates/client-revocation-list.erb
@@ -1,0 +1,7 @@
+<%
+if_p("ha_proxy.client_revocation_list") do |pem|
+%>
+<%= pem %>
+<%
+end
+%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -170,7 +170,18 @@ frontend https-in
     <% if p("ha_proxy.accept_proxy") %>
     bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.client_cert") == true -%>
+      <%
+        client_ca_certs = nil
+        if_p("ha_proxy.client_ca_file") { client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem" }
+        unless client_ca_certs
+          client_ca_certs = "/etc/ssl/certs/ca-certificates.crt"
+        end
+      -%> ca-file <%= client_ca_certs %> verify optional <% if_p("ha_proxy.client_cert_ignore_err") do -%>
+      crt-ignore-err <%= p("ha_proxy.client_cert_ignore_err")-%> <% end -%>
+      <% if_p("ha_proxy.client_revocation_list") do -%>
+        crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem <% end -%>
+      <% end -%>
     <% end %>
     <% if_p("ha_proxy.cidr_whitelist") do %>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
@@ -182,6 +193,10 @@ frontend https-in
     <% end %>
     <% if p("ha_proxy.block_all") then %>
     tcp-request content reject
+    <% end %>
+
+    <% if p("ha_proxy.client_cert") == true %>
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
     <% end %>
 
     <% if p("ha_proxy.hsts_enable") %>


### PR DESCRIPTION
The client certificate will be requested
If no cert prompt, the handshake still go through one way ssl
If a client certificate prompt, ha proxy will pass through and carry a header with cert base64 encoding
The header match what gorouter supports https://github.com/cloudfoundry-incubator/routing-release/blob/develop/jobs/gorouter/spec#L115   as x-forwarded-client-cert for mutual ssl purpose to backend apps