### PR TITLE
Backend client cert

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -14,6 +14,7 @@ templates:
   certs.ttar.erb:            config/certs.ttar
   ssl_redirect.map.erb:      config/ssl_redirect.map
   backend-ca-certs.erb:      config/backend-ca-certs.pem
+  backend-crt.erb:           config/backend-crt.pem
   helpers/ctl_setup.sh:      helpers/ctl_setup.sh
   helpers/ctl_utils.sh:      helpers/ctl_utils.sh
   properties.sh.erb:         data/properties.sh
@@ -201,6 +202,16 @@ properties:
   ha_proxy.client_cert_ca:
     description: "path for CA certs to validate client certificate"
     default: /etc/ssl/certs/ca-certificates.crt
+
+  ha_proxy.backend_crt:
+    description: "provides client certificate to backend server to do mutual ssl"
+    example: |
+      -----BEGIN CERTIFICATE-----
+      ******
+      -----END CERTIFICATE-----
+      -----BEGIN PRIVATE KEY-----
+      ******
+      -----END PRIVATE KEY-----
 
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -194,6 +194,14 @@ properties:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
 
+  ha_proxy.client_cert:
+    description: "Enable haproxy mutual auth and produce a client cert header (X-Forwarded-Client-Cert) to offload mutual ssl client certificate to backend"
+    default: false
+
+  ha_proxy.client_cert_ca:
+    description: "path for CA certs to validate client certificate"
+    default: /etc/ssl/certs/ca-certificates.crt
+
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"
     default: []

--- a/jobs/haproxy/templates/backend-crt.erb
+++ b/jobs/haproxy/templates/backend-crt.erb
@@ -1,0 +1,7 @@
+<%
+if_p("ha_proxy.backend_crt") do |pem|
+%>
+<%= pem %>
+<%
+end
+%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -170,7 +170,7 @@ frontend https-in
     <% if p("ha_proxy.accept_proxy") %>
     bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.client_cert") == true %> ca-file <%= p("ha_proxy.client_cert_ca") %> verify optional crt-ignore-err all<% end %>
     <% end %>
     <% if_p("ha_proxy.cidr_whitelist") do %>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
@@ -182,6 +182,10 @@ frontend https-in
     <% end %>
     <% if p("ha_proxy.block_all") then %>
     tcp-request content reject
+    <% end %>
+
+    <% if p("ha_proxy.client_cert") == true %>
+      http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
     <% end %>
 
     <% if p("ha_proxy.hsts_enable") %>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -294,6 +294,7 @@ backend http-routers
     <% backend_servers.each_with_index do |ip, index| -%>
         server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
         resolvers default <% end -%>
+        <% if_p("ha_proxy.backend_crt") do -%> crt  /var/vcap/jobs/haproxy/config/backend-crt.pem <% end -%>
         check inter 1000 <% if p("ha_proxy.backend_ssl").downcase == "verify" then -%>
         ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem <% if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname | -%>
         verifyhost <%= verify_hostname %> <% end -%>


### PR DESCRIPTION
This commit provides the capability to do mutual ssl with backend server.
The idea helps https://github.com/cloudfoundry-incubator/routing-release/blob/develop/jobs/gorouter/spec#L120

In *forward* mode (not *always_forward*): gorouter needs a client certificate from ha proxy to do mutual ssl