### PR TITLE
provides capabilities to do backend mutual ssl

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -14,6 +14,7 @@ templates:
   certs.ttar.erb:            config/certs.ttar
   ssl_redirect.map.erb:      config/ssl_redirect.map
   backend-ca-certs.erb:      config/backend-ca-certs.pem
+  backend-crt.erb:           config/backend-crt.pem
   helpers/ctl_setup.sh:      helpers/ctl_setup.sh
   helpers/ctl_utils.sh:      helpers/ctl_utils.sh
   properties.sh.erb:         data/properties.sh
@@ -193,6 +194,16 @@ properties:
       rsp_headers:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
+
+  ha_proxy.backend_crt:
+    description: "provides client certificate to backend server to do mutual ssl"
+    example: |
+      -----BEGIN CERTIFICATE-----
+      ******
+      -----END CERTIFICATE-----
+      -----BEGIN PRIVATE KEY-----
+      ******
+      -----END PRIVATE KEY-----
 
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"

--- a/jobs/haproxy/templates/backend-crt.erb
+++ b/jobs/haproxy/templates/backend-crt.erb
@@ -1,0 +1,7 @@
+<%
+if_p("ha_proxy.backend_crt") do |pem|
+%>
+<%= pem %>
+<%
+end
+%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -290,6 +290,7 @@ backend http-routers
     <% backend_servers.each_with_index do |ip, index| -%>
         server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
         resolvers default <% end -%>
+        <% if_p("ha_proxy.backend_crt") do -%> crt  /var/vcap/jobs/haproxy/config/backend-crt.pem <% end -%>
         check inter 1000 <% if p("ha_proxy.backend_ssl").downcase == "verify" then -%>
         ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem <% if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname | -%>
         verifyhost <%= verify_hostname %> <% end -%>


### PR DESCRIPTION
This commit provides the capability to do mutual ssl with backend server.
The idea helps https://github.com/cloudfoundry-incubator/routing-release/blob/develop/jobs/gorouter/spec#L120

In forward mode (not always_forward): gorouter needs a client certificate from ha proxy to do mutual ssl