### PR TITLE
uses https instead of ssh to clone ttar submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/ttar"]
 	path = src/ttar
-	url = git@github.com:jhunt/ttar
+	url = https://github.com/jhunt/ttar.git


### PR DESCRIPTION
Since the repo is public cloning this repo should not require ssh

Signed-off-by: Andrew Crump <acrump@pivotal.io>