### PR TITLE
Support strict-sni setting for SSL/TLS negotiation

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -51,6 +51,9 @@ properties:
   ha_proxy.trusted_domain_cidrs:
     description: "Space separated trusted cidr blocks for internal_only_domains"
     default: 0.0.0.0/32
+  ha_proxy.strict_sni:
+    description: "Optional setting to decide whether the SSL/TLS negotiation is allowed only if the client provided an SNI which strict match a certificate. If set to true, the default certificate is not used"
+    default: false
   ha_proxy.ssl_pem:
     description: |
       Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'cert_chain' and 'private_key',

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -168,9 +168,9 @@ end
 frontend https-in
     mode http
     <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.strict_sni") %> strict-sni <% end %>
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.client_cert") == true -%>
+    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.strict_sni") %> strict-sni <% end %> <% if p("ha_proxy.client_cert") == true -%>
       <%
         client_ca_certs = nil
         if_p("ha_proxy.client_ca_file") { client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem" }


### PR DESCRIPTION
By default the first loaded certificate will be presented, if no SNI is provided by the client or if the SSL library does not support TLS extensions, or if the client provides an SNI hostname which does not match any certificate. It is not always the desired behavior. 
The strict-sni setting helps to configure the SSL/TLS negotiation. If strict-sni is set (to true), the negotiation is allowed only if the client provided an SNI which match a certificate. The default certificate is not used in this case.