### PR TITLE
Add support for CF TCP Routing

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -32,6 +32,10 @@ consumes:
     type: ssh_proxy
     optional: true
 
+  - name: tcp_router
+    type: tcp-router
+    optional: true
+
 properties:
   ha_proxy.threads:
     description: "Optional number of threads per VM"
@@ -286,3 +290,7 @@ properties:
   ha_proxy.block_all:
     description: "Optionally block all incoming traffic to http(s). Use in conjunction with whitelist."
     default: false
+
+  ha_proxy.tcp_routing.port_range:
+    description: "A range of ports for haproxy to listen on to enable CF TCP Routing. Used only if 'tcp_router' link is present."
+    default: 1024-1123

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -339,6 +339,19 @@ backend http-routed-backend-<%= prefix_hash %>
     <% end -%>
 <% end -%>
 
+<%# CF TCP Routing %>
+<% if_link("tcp_router") do |tcp_router| %>
+frontend cf_tcp_routing
+  mode tcp
+  bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
+  default_backend cf_tcp_routers
+backend cf_tcp_routers
+  mode tcp
+  <% tcp_router.instances.each_with_index do |instance, index| %>
+  server node<%= index %> <%= instance.address %> check port 80 inter 1000
+  <% end %>
+<% end %>
+
 <%# TCP Backends %>
 <%
 tcp = p("ha_proxy.tcp")


### PR DESCRIPTION
##### Motivation:
We would like to provide a port range  to simplify configuration needed for CF TCP routing when using HAProxy as the load balancer.

##### Changes introduced by this PR: 
* Consumes `tcp_router` link from the [routing-release](https://github.com/cloudfoundry/routing-release/blob/d1e5369935688080e69335058922c2f0970dbfdb/jobs/tcp_router/spec#L18-L20).
* Adds `ha_proxy.tcp_routing.port_range` property to the `haproxy` job. This property is used only if `tcp_router` link is present.

##### Notes
The default value for the `ha_proxy.tcp_routing.port_range` property comes from [`cf-deployment`](https://github.com/cloudfoundry/cf-deployment/blob/43e9eb3fa9ab4f1e16659f6ec8f38811e12023a9/cf-deployment.yml#L732).
  