### PR TITLE
Fixes for keepalived stop

### DIFF
--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -7,6 +7,8 @@ CONF_DIR=${APP_DIR}/config
 RUN_DIR=/var/vcap/sys/run/keepalived
 LOG_DIR=/var/vcap/sys/log/keepalived
 
+source /var/vcap/packages/keepalived/common/utils.sh
+
 interface_for_ip() {
     local ip=$1
     local network=""
@@ -96,7 +98,13 @@ case $1 in
   stop)
     echo "Stopping keepalived... ($(date))"
     for PIDFILE in ${RUN_DIR}/*.pid; do
-        kill -9 -$(cat $PIDFILE)
+        pid=$(cat $PIDFILE)
+        [[ -z "${pid}" ]] && continue
+        kill "${pid}"
+        wait_pid_death "${pid}" 25
+        if pid_is_running "${pid}"; then
+            kill -9 ${pid}
+        fi
         rm -f $PIDFILE
     done
 

--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -89,7 +89,7 @@ case $1 in
         -f $CONF_DIR/keepalived.config \
         --pid=$RUN_DIR/keepalived.pid \
         --vrrp_pid=${RUN_DIR}/vrrp.pid \
-        --checkers_pid=${RUN_DIR}/vrrp.pid \
+        --checkers_pid=${RUN_DIR}/checkers.pid \
         >> ${LOG_DIR}/keepalived.log 2>&1 &
     ;;
 

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -1,6 +1,10 @@
 # abort script on any command that exits with a non zero value
 set -e -x
 
+# Copy common utils
+mkdir -p ${BOSH_INSTALL_TARGET}/common
+cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
+
 #Source can be downloaded at : http://www.keepalived.org/software/keepalived-1.2.24.tar.gz
 tar xzvf keepalived/keepalived-1.2.24.tar.gz
 cd keepalived-1.2.24/

--- a/packages/keepalived/spec
+++ b/packages/keepalived/spec
@@ -4,5 +4,6 @@ name: keepalived
 dependencies: []
 
 files:
+- common/utils.sh
 - keepalived/keepalived-1.2.24.tar.gz
 

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+function pid_is_running() {
+  declare pid="$1"
+  ps -p "${pid}" >/dev/null 2>&1
+}
+
+# pid_guard
+#
+# @param pidfile
+# @param name [String] an arbitrary name that might show up in STDOUT on errors
+#
+# Run this before attempting to start new processes that may use the same :pidfile:.
+# If an old process is running on the pid found in the :pidfile:, exit 1. Otherwise,
+# remove the stale :pidfile: if it exists.
+#
+function pid_guard() {
+  declare pidfile="$1" name="$2"
+
+  echo "------------ STARTING $(basename "$0") at $(date) --------------" | tee /dev/stderr
+
+  if [ ! -f "${pidfile}" ]; then
+    return 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if pid_is_running "${pid}"; then
+    echo "${name} is already running, please stop it first"
+    exit 1
+  fi
+
+  echo "Removing stale pidfile"
+  rm "${pidfile}"
+}
+
+# wait_pid_death
+#
+# @param pid
+# @param timeout
+#
+# Watch a :pid: for :timeout: seconds, waiting for it to die.
+# If it dies before :timeout:, exit 0. If not, exit 1.
+#
+# Note that this should be run in a subshell, so that the current
+# shell does not exit.
+#
+function wait_pid_death() {
+  declare pid="$1" timeout="$2"
+
+  local countdown
+  countdown=$(( timeout * 10 ))
+
+  while true; do
+    if ! pid_is_running "${pid}"; then
+      return 0
+    fi
+
+    if [ ${countdown} -le 0 ]; then
+      return 1
+    fi
+
+    countdown=$(( countdown - 1 ))
+    sleep 0.1
+  done
+}
+
+# kill_and_wait
+#
+# @param pidfile
+# @param timeout [default 25s]
+#
+# For a pid found in :pidfile:, send a `kill -15` TERM, then wait for :timeout: seconds to
+# see if it dies on its own. If not, send it a `kill -9`. If the process does die,
+# exit 0 and remove the :pidfile:. If after all of this, the process does not actually
+# die, exit 1.
+#
+# Note:
+# Monit default timeout for start/stop is 30s
+# Append 'with timeout {n} seconds' to monit start/stop program configs
+#
+function kill_and_wait() {
+  declare pidfile="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+
+  if [ ! -f "${pidfile}" ]; then
+    echo "Pidfile ${pidfile} doesn't exist"
+    exit 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if [ -z "${pid}" ]; then
+    echo "Unable to get pid from ${pidfile}"
+    exit 1
+  fi
+
+  if ! pid_is_running "${pid}"; then
+    echo "Process ${pid} is not running"
+    rm -f "${pidfile}"
+    exit 0
+  fi
+
+  echo "Killing ${pidfile}: ${pid} "
+  kill "${pid}"
+
+  if ! wait_pid_death "${pid}" "${timeout}"; then
+    if [ "${sigkill_on_timeout}" = "1" ]; then
+      echo "Kill timed out, using kill -9 on ${pid}"
+      kill -9 "${pid}"
+      sleep 0.5
+    fi
+  fi
+
+  if pid_is_running "${pid}"; then
+    echo "Timed Out"
+    exit 1
+  else
+    echo "Stopped"
+    rm -f "${pidfile}"
+  fi
+}
+
+running_in_container() {
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
+}


### PR DESCRIPTION
Checker's pid is not tracked so it's process is not stopped.

PIDs are terminated without giving them a chance to end their children so these stay running as well.