### PR TITLE
allow to use crt-list configurations

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -85,10 +85,10 @@ properties:
       Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing at least the field 'ssl_pem'.
       The field 'ssl_pem' itself is either an object containing fields 'cert_chain' and 'private_key', or a single string containing the cert chain and the private key.
       The following fields are optional:
-      - 'client_ca_file' (see ha_proxy.client_ca_file)
+      - 'client_ca_file' (overrides ha_proxy.client_ca_file)
       - 'verify' (allowed values: [none|optional|required])
-      - 'ssl_ciphers' (see ha_proxy.ssl_ciphers)
-      - 'client_revocation_list' (see ha_proxy.client_revocation_list)
+      - 'ssl_ciphers' (overrides ha_proxy.ssl_ciphers)
+      - 'client_revocation_list' (overrides ha_proxy.client_revocation_list)
       - 'snifilter' (either a string or an array of strings)
     example:
       crt_list:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -80,6 +80,50 @@ properties:
         -----BEGIN RSA PRIVATE KEY-----
         -----END RSA PRIVATE KEY-----
     default: ~
+  ha_proxy.crt_list:
+    description: |
+      Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing at least the field 'ssl_pem'.
+      The field 'ssl_pem' itself is either an object containing fields 'cert_chain' and 'private_key', or a single string containing the cert chain and the private key.
+      The following fields are optional:
+      - 'client_ca_file' (see ha_proxy.client_ca_file)
+      - 'verify' (allowed values: [none|optional|required])
+      - 'ssl_ciphers' (see ha_proxy.ssl_ciphers)
+      - 'client_revocation_list' (see ha_proxy.client_revocation_list)
+      - 'snifilter' (either a string or an array of strings)
+    example:
+      crt_list:
+      - ssl_pem: |
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+          -----BEGIN RSA PRIVATE KEY-----
+          -----END RSA PRIVATE KEY-----
+      - ssl_pem:
+          cert_chain: |
+            -----BEGIN CERTIFICATE-----
+            -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            -----END CERTIFICATE-----
+          private_key: |
+            -----BEGIN RSA PRIVATE KEY-----
+            -----END RSA PRIVATE KEY-----
+        client_ca_file: |
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+        verify: required
+        ssl_ciphers: AES:ALL:!aNULL:!eNULL:+RC4:@STRENGTH
+        client_revocation_list: |
+          -----BEGIN X509 CRL-----
+          -----END X509 CRL-----
+          -----BEGIN X509 CRL-----
+          -----END X509 CRL-----
+        snifilter:
+        - "*.domain.tld"
+        - "!secure.domain.tld"
+    default: ~
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
   ha_proxy.enable_health_check_http:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -85,11 +85,13 @@ properties:
       Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing at least the field 'ssl_pem'.
       The field 'ssl_pem' itself is either an object containing fields 'cert_chain' and 'private_key', or a single string containing the cert chain and the private key.
       The following fields are optional:
-      - 'client_ca_file' (overrides ha_proxy.client_ca_file)
+      - 'client_ca_file' (replaces ha_proxy.client_ca_file)
       - 'verify' (allowed values: [none|optional|required])
       - 'ssl_ciphers' (overrides ha_proxy.ssl_ciphers)
-      - 'client_revocation_list' (overrides ha_proxy.client_revocation_list)
+      - 'client_revocation_list' (replaces ha_proxy.client_revocation_list)
       - 'snifilter' (either a string or an array of strings)
+      The global option ha_proxy.client_cert has to be set to 'true', if there are crt_list entries with mutual auth configuration ('client_ca_file', 'client_revocation_list' and 'verify'!='none')
+      To avoid confusing configurations, it's not allowed to specify 'client_ca_file' and 'client_revocation_list' both globally AND in crt_list entries.
     example:
       crt_list:
       - ssl_pem: |

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -16,3 +16,70 @@ if_p("ha_proxy.ssl_pem") do |pem|
   end
 end
 %>
+<%
+if_p("ha_proxy.crt_list") do |crt_list|
+  if !crt_list.is_a?(Array)
+    crt_list = [crt_list]
+  end
+%>
+========================== 0600 /var/vcap/jobs/haproxy/config/ssl/crt-list
+<%
+  crt_list.each_with_index do |list_entry, i|
+    sslbindconf=""
+    if list_entry.key?("client_ca_file")
+      sslbindconf += " ca-file /var/vcap/jobs/haproxy/config/ssl/ca-file-"+i.to_s+".pem"
+    end
+    if list_entry.key?("client_revocation_list")
+      sslbindconf += " crl-file /var/vcap/jobs/haproxy/config/ssl/crl-file-"+i.to_s+".pem"
+    end
+    if list_entry.key?("verify")
+      sslbindconf += " verify " + list_entry["verify"]
+    end
+    if list_entry.key?("ssl_ciphers")
+      sslbindconf += " ciphers " + list_entry["ssl_ciphers"]
+    end
+
+    if sslbindconf != ""
+      sslbindconf = " ["+sslbindconf.strip+"]"
+    end
+
+    snifilter=""
+    if list_entry.key?("snifilter")
+      if list_entry["snifilter"].is_a?(Array)
+        list_entry["snifilter"].each { |sni|  snifilter += " " + sni }
+      else
+        snifilter=" "+list_entry["snifilter"]
+      end
+    end
+
+%>/var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem<%= sslbindconf %><%= snifilter%>
+<%
+  end
+
+  crt_list.each_with_index do |list_entry, i|
+    pem_block = list_entry["ssl_pem"];
+    client_ca_file=""
+    if pem_block.is_a?(Hash)
+      pem_block = pem_block['cert_chain'].strip + "\n" + pem_block['private_key'].strip
+    end
+%>
+========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
+<%= pem_block %>
+<%
+    if list_entry.key?("client_ca_file")
+      pem_block=list_entry["client_ca_file"];
+%>
+========================== 0600 /var/vcap/jobs/haproxy/config/ssl/ca-file-<%= i %>.pem
+<%= pem_block %>
+<%
+    end
+    if list_entry.key?("client_revocation_list")
+      pem_block=list_entry["client_revocation_list"];
+%>
+========================== 0600 /var/vcap/jobs/haproxy/config/ssl/crl-file-<%= i %>.pem
+<%= pem_block %>
+<%
+    end
+  end
+end
+%>

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -24,16 +24,35 @@ if_p("ha_proxy.crt_list") do |crt_list|
 %>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/crt-list
 <%
+  global_option_client_cert = false
+  if_p("ha_proxy.client_cert") do |value| 
+    global_option_client_cert = value
+  end
   crt_list.each_with_index do |list_entry, i|
     sslbindconf=""
     if list_entry.key?("client_ca_file")
+      if_p("ha_proxy.client_ca_file") do
+        abort("Conflicting configuration. Please configure 'client_ca_file' either globally OR in 'crt_list' entries, but not both")
+      end
+      if (global_option_client_cert != true)
+        abort("A 'crt_list' entry with a 'client_ca_file' requires the global option 'client_cert' to be 'true'")
+      end
       sslbindconf += " ca-file /var/vcap/jobs/haproxy/config/ssl/ca-file-"+i.to_s+".pem"
     end
     if list_entry.key?("client_revocation_list")
+      if_p("ha_proxy.client_revocation_list") do
+        abort("Conflicting configuration. Please configure 'client_revocation_list' either globally OR in 'crt_list' entries, but not both")
+      end
+      if (global_option_client_cert != true)
+        abort("A 'crt_list' entry with a 'client_revocation_list' requires the global option 'client_cert' to be 'true'")
+      end
       sslbindconf += " crl-file /var/vcap/jobs/haproxy/config/ssl/crl-file-"+i.to_s+".pem"
     end
     if list_entry.key?("verify")
       sslbindconf += " verify " + list_entry["verify"]
+      if ((global_option_client_cert != true) && (list_entry["verify"] != "none"))
+        abort("A 'crt_list' entry with 'verify' not 'none' requires the global option 'client_cert' to be 'true'")
+      end
     end
     if list_entry.key?("ssl_ciphers")
       sslbindconf += " ciphers " + list_entry["ssl_ciphers"]

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -164,13 +164,28 @@ end
 
 <%# HTTPS Frontend %>
 
-<% if_p("ha_proxy.ssl_pem") do |pem| %>
+<%
+ssl_enabled = false
+crt_config = ""
+if_p("ha_proxy.ssl_pem") do
+    ssl_enabled = true
+    crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
+end
+if_p("ha_proxy.crt_list") do
+    if ssl_enabled == true
+        abort("Please configure eihter ssl_pem or crt_list, but not both")
+    end
+    ssl_enabled=true
+    crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"
+end
+%>
+<% if ssl_enabled == true %>
 frontend https-in
     mode http
     <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.strict_sni") %> strict-sni <% end %>
+    bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl <%= crt_config %> <% if p("ha_proxy.strict_sni") %> strict-sni <% end %>
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 ssl crt /var/vcap/jobs/haproxy/config/ssl <% if p("ha_proxy.strict_sni") %> strict-sni <% end %> <% if p("ha_proxy.client_cert") == true -%>
+    bind <%= p("ha_proxy.binding_ip") %>:443 ssl <%= crt_config %> <% if p("ha_proxy.strict_sni") %> strict-sni <% end %> <% if p("ha_proxy.client_cert") == true -%>
       <%
         client_ca_certs = nil
         if_p("ha_proxy.client_ca_file") { client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem" }
@@ -248,9 +263,9 @@ end
 frontend wss-in
     mode http
     <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:4443 accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:4443 accept-proxy ssl <%= crt_config %>
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:4443 ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:4443 ssl <%= crt_config %>
     <% end %>
     default_backend http-routers
 <%
@@ -369,9 +384,9 @@ end %>
     mode tcp
 <% if tcp_proxy["ssl"] %>
     <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> accept-proxy ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> accept-proxy ssl <%= crt_config %>
     <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> ssl crt /var/vcap/jobs/haproxy/config/ssl
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> ssl <%= crt_config %>
     <% end %>
 <% else %>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -173,7 +173,7 @@ if_p("ha_proxy.ssl_pem") do
 end
 if_p("ha_proxy.crt_list") do
     if ssl_enabled == true
-        abort("Please configure either ssl_pem or crt_list, but not both")
+        abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
     end
     ssl_enabled=true
     crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -173,7 +173,7 @@ if_p("ha_proxy.ssl_pem") do
 end
 if_p("ha_proxy.crt_list") do
     if ssl_enabled == true
-        abort("Please configure eihter ssl_pem or crt_list, but not both")
+        abort("Please configure either ssl_pem or crt_list, but not both")
     end
     ssl_enabled=true
     crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"


### PR DESCRIPTION
Hi @geofffranks, 

as @jgf already mentioned in slack,I've prepared a pull request for the crt-list feature of haproxy-1.8.x. Only things that are already supported by the haproxy-boshrelease are now also supported by crt-lists. The one and only exception is the "verify" option.
The existing "ssl_pem" feature has not been touched, but if you put both "ssl_pem" and "crt_list" in your manifest, an error will be reported.

Please have a look at my changes.    

crt-list is documented here:
  https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1-crt-list

The new field 'haproxy.crt_list' replaces 'haproxy.ssl_pem' and allows to
specify sslbindconf and snifilter options for each certificate

Only a small subset of the allowed sslbindconf options is supported:

sslbindconf   | field in manifest
--------------|-------------------------
"npn"         | not supported
"alpn"        | not supported
"verify"      | "verify"
"ca-file"     | "client_ca_file"
"no-ca-names" | not supported
"crl-file"    | "client_revocation_list"
"ecdhe"       | not supported
"curves"      | not supported
"ciphers"     | "ssl_ciphers"
"ssl-min-ver" | not supported
"ssl-max-ver" | not supported