### PR TITLE
Ensure frontend options are applied appropriately to all frontends

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,39 @@
+# New Features
+- `haproxy` has been upgraded to v1.8.4 from v1.6.12
+- `haproxy` is now build with pcre2 10.32, and pcre2 JIT enabled
+- With the introduction of haproxy v1.8.4, there is now support for
+  per-certificate TLS binding options. To make use of this, use
+  `ha_proxy.crt_list` instead of `ha_proxy.ssl_pem`. It allows
+  custom `client_ca_file`, `verify`, `ssl_ciphers`, `client_revocation_list`,
+  settings for each provided certificate, as well as an `snifilter` to
+  restrict use of each cert to specific domains.
+
+  For more information:
+  - https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1-crt-list
+  - https://github.com/cloudfoundry-incubator/haproxy-boshrelease/blob/master/jobs/haproxy/spec#L83-L127
+
+# Fixes
+- `haproxy.config.erb` has been cleaned up considerably, and
+  should be a lot more readable pre and post template rendering.
+- The HTTP frontend now supports accept-proxy.
+- Bugs where accept-proxy was not honored during mutual TLS have been
+  resolved
+- `ha_proxy.client_cert` is no longer required to enable TLS. It is
+  still honored to enable mutual tls, but the boshrelease will also
+  use the presence of the following parameters to enable mutual TLS:
+  - `ha_proxy.client_ca_file`
+  - `ha_proxy.client_revocation_list`
+  - `ha_proxy.crt_list.<i>.client_ca_file`
+  - `ha_proxy.crt_list.<i>.client_revocation_list`
+  - `ha_proxy.crt_list.<i>.verify` - only when value is not "none"
+- The following options are now honored in the `:4443` backend:
+  - `ha_proxy.cidr_whitelist`
+  - `ha_proxy.cidr_blacklist`
+  - `ha_proxy.block_all`
+  - `ha_proxy.hsts_*`
+  - `ha_proxy.rsp_headers`
+- The `X-Forwarded-Client_Cert` header is now set for requests in the `:4443`
+  backend.
+- The `X-Forwarded-Proto` header behavior in the `:4443` backend now
+  matches the behavior in the `:443` backend
+- Spec descriptions + examples were updated for `resolvers`

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -307,8 +307,8 @@ properties:
     description: "List of DNS servers"
     example:
       resolvers:
-        private: 10.0.0.2
-        public: 8.8.8.8
+      - private: 10.0.0.2
+      - public: 8.8.8.8
   ha_proxy.dns_hold:
     description: "DNS Hold time"
     default: 10s

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -24,18 +24,11 @@ if_p("ha_proxy.crt_list") do |crt_list|
 %>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/crt-list
 <%
-  global_option_client_cert = false
-  if_p("ha_proxy.client_cert") do |value| 
-    global_option_client_cert = value
-  end
   crt_list.each_with_index do |list_entry, i|
     sslbindconf=""
     if list_entry.key?("client_ca_file")
       if_p("ha_proxy.client_ca_file") do
         abort("Conflicting configuration. Please configure 'client_ca_file' either globally OR in 'crt_list' entries, but not both")
-      end
-      if (global_option_client_cert != true)
-        abort("A 'crt_list' entry with a 'client_ca_file' requires the global option 'client_cert' to be 'true'")
       end
       sslbindconf += " ca-file /var/vcap/jobs/haproxy/config/ssl/ca-file-"+i.to_s+".pem"
     end
@@ -43,16 +36,10 @@ if_p("ha_proxy.crt_list") do |crt_list|
       if_p("ha_proxy.client_revocation_list") do
         abort("Conflicting configuration. Please configure 'client_revocation_list' either globally OR in 'crt_list' entries, but not both")
       end
-      if (global_option_client_cert != true)
-        abort("A 'crt_list' entry with a 'client_revocation_list' requires the global option 'client_cert' to be 'true'")
-      end
       sslbindconf += " crl-file /var/vcap/jobs/haproxy/config/ssl/crl-file-"+i.to_s+".pem"
     end
     if list_entry.key?("verify")
       sslbindconf += " verify " + list_entry["verify"]
-      if ((global_option_client_cert != true) && (list_entry["verify"] != "none"))
-        abort("A 'crt_list' entry with 'verify' not 'none' requires the global option 'client_cert' to be 'true'")
-      end
     end
     if list_entry.key?("ssl_ciphers")
       sslbindconf += " ciphers " + list_entry["ssl_ciphers"]

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -49,8 +49,15 @@ if_p("ha_proxy.crt_list") do
 end
 
 client_ca_certs = "/etc/ssl/certs/ca-certificates.crt"
-if_("ha_proxy.client_ca_file") do
+if_p("ha_proxy.client_ca_file") do
   client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem"
+end
+
+strict_sni = ""
+if_p("ha_proxy.strict_sni") do |sni|
+  if sni == true
+    strict_sni = "strict-sni"
+  end
 end
 
 tls_options = "#{crt_config} #{strict_sni}"
@@ -59,7 +66,7 @@ if mutual_tls_enabled == true
   if_p("ha_proxy.client_cert_ignore_err") do |ignore_errs|
     tls_options = "#{tls_options} crt-ignore-err #{ignore_errs}"
   end
-  if_p("ha_proxy.client_revocation_list" do
+  if_p("ha_proxy.client_revocation_list") do
     tls_options = "#{tls_options} crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem"
   end
 end
@@ -71,22 +78,22 @@ tls_bind_options = "#{accept_proxy} ssl #{tls_options}"
 global
     log <%= p('ha_proxy.syslog_server') %> syslog <%= p('ha_proxy.log_level') %>
     daemon
-    <% if p("ha_proxy.threads") > 1 %>
+    <% if p("ha_proxy.threads") > 1 -%>
     nbproc <%= p("ha_proxy.threads") %>
-    <% end %>
+    <% end -%>
     user vcap
     group vcap
     maxconn 64000
     spread-checks 4
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
     tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
-    <% if p("ha_proxy.threads") > 1 %>
-      <% 1.upto(p("ha_proxy.threads")) do |proc| %>
+    <% if p("ha_proxy.threads") > 1 -%>
+      <% 1.upto(p("ha_proxy.threads")) do |proc| -%>
     stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 level admin process <%= proc%>
-      <% end %>
-    <% else %>
+      <% end -%>
+    <% else -%>
     stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
-    <% end %>
+    <% end -%>
     stats timeout 2m
     ssl-default-bind-options <%= ssl_flags %>
     ssl-default-bind-ciphers <%= p("ha_proxy.ssl_ciphers") %>
@@ -133,157 +140,130 @@ listen health_check_http_url
     monitor fail if http-routers_down
 <% end %>
 
-<%# HTTP Frontend %>
-
-<%
-if_p("ha_proxy.resolvers") do |resolvers|
-%>
+<% if_p("ha_proxy.resolvers") do |resolvers| -%>
 resolvers default
     hold valid <%= p("ha_proxy.dns_hold") %>
-<%
-    resolvers.each do |resolver|
-%>
+  <% resolvers.each do |resolver| %>
     nameserver <%= resolver.keys[0] %> <%= resolver.values[0] %>:53
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-
-<% unless p("ha_proxy.disable_http") %>
+<% unless p("ha_proxy.disable_http") -%>
+# HTTP Frontend {{{
 frontend http-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %>
     <% if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
-    <% end %>
-    <% if_p("ha_proxy.cidr_blacklist") do %>
+    <% end -%>
+    <% if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
-    <% end %>
-    <% if p("ha_proxy.block_all") then %>
+    <% end -%>
+    <% if p("ha_proxy.block_all") then -%>
     tcp-request content reject
-    <% end %>
+    <% end -%>
 
     capture request header Host len 256
     default_backend http-routers
-<%
-if_p("ha_proxy.headers") do |headers|
-  headers.each do |header, value|
-%>
+<% if_p("ha_proxy.headers") do |headers| -%>
+  <% headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-<%
-if_p("ha_proxy.rsp_headers") do |rsp_headers|
-  rsp_headers.each do |rsp_header, value|
-%>
+<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+  <% rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-<% if p("ha_proxy.internal_only_domains").size > 0 %>
+<% if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-<% p("ha_proxy.internal_only_domains").each do |domain| %>
+  <% p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-<% end %>
+  <% end -%>
     http-request deny if internal !private
-<% end %>
+<% end -%>
 
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| %>
-<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] %>
+<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+    <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end %>
+<% end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ http if ! xfp_exists
 
-<% if p("ha_proxy.https_redirect_all") == true %>
+<% if p("ha_proxy.https_redirect_all") == true -%>
     redirect scheme https code 301 if !{ ssl_fc }
-<% end %>
-<% unless p("ha_proxy.https_redirect_all") == true %>
+<% end -%>
+<% unless p("ha_proxy.https_redirect_all") == true -%>
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
-<% end %>
-
-<% end %>
-
-<%# HTTPS Frontend %>
+<% end -%>
+# }}}
+<% end -%>
 
 <% if ssl_enabled == true -%>
-# HTTPS Frontend
+# HTTPS Frontend {{{
 frontend https-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= tls_bind_options %>
-
     <% if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
-    <% end %>
-    <% if_p("ha_proxy.cidr_blacklist") do %>
+    <% end -%>
+    <% if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
-    <% end %>
-    <% if p("ha_proxy.block_all") then %>
+    <% end -%>
+    <% if p("ha_proxy.block_all") then -%>
     tcp-request content reject
-    <% end %>
+    <% end -%>
 
     <% if mutual_tls_enabled == true -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
-    <% end %>
+    <% end -%>
 
-    <% if p("ha_proxy.hsts_enable") %>
+    <% if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
-    <% end %>
+    <% end -%>
     capture request header Host len 256
     default_backend http-routers
-<%
-if_p("ha_proxy.headers") do |headers|
-  headers.each do |header, value|
-%>
+<% if_p("ha_proxy.headers") do |headers| -%>
+  <% headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-<%
-if_p("ha_proxy.rsp_headers") do |rsp_headers|
-  rsp_headers.each do |rsp_header, value|
-%>
+<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+  <%  rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-<% if p("ha_proxy.internal_only_domains").size > 0 %>
+<% if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-<% p("ha_proxy.internal_only_domains").each do |domain| %>
+<% p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-<% end %>
+<% end -%>
     http-request deny if internal !private
-<% end %>
+<% end -%>
 
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| %>
-<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] %>
-  acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-  use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end %>
+<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+  <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+    acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
+    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
+<% end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
 
-<% end %>
+# }}}
+<% end -%>
 
-<%# HTTPS Websockets Frontend %>
-
-<% if p("ha_proxy.enable_4443") == true %>
+<% if p("ha_proxy.enable_4443") == true -%>
+# HTTPS Websockets Frontend {{{
 frontend wss-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= tls_bind_options %>
@@ -308,52 +288,44 @@ frontend wss-in
     <% end -%>
     capture request header Host len 256
     default_backend http-routers
-<%
-if_p("ha_proxy.headers") do |headers|
-  headers.each do |header, value|
-%>
+<% if_p("ha_proxy.headers") do |headers| -%>
+  <% headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
-%>
+  <% end -%>
+<% end -%>
 
-<%
-if_p("ha_proxy.rsp_headers") do |rsp_headers|
-  rsp_headers.each do |rsp_header, value|
--%>
+<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+  <% rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
-<%
-  end
-end
--%>
+  <% end -%>
+<% end -%>
 
-<% if p("ha_proxy.internal_only_domains").size > 0 %>
+<% if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-<% p("ha_proxy.internal_only_domains").each do |domain| %>
+<% p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-<% end %>
+<% end -%>
     http-request deny if internal !private
-<% end %>
+<% end -%>
 
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| %>
-<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] %>
-  acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
-  use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end %>
+<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+    <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+    acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
+    use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
+<% end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
 # }}}
-<% end %>
+<% end -%>
 
 # Default Backend {{{
 backend http-routers
     mode http
     balance roundrobin
-    <% if p("ha_proxy.compress_types") != "" %>
+    <% if p("ha_proxy.compress_types") != "" -%>
     compression algo gzip
     compression type <%= p("ha_proxy.compress_types") %>
-    <% end %>
+    <% end -%>
 
     <%
     backend_servers = []
@@ -365,7 +337,7 @@ backend http-routers
         backend_servers = servers
         backend_port = p("ha_proxy.backend_port")
     end
-    %>
+    -%>
 
     <% backend_servers.each_with_index do |ip, index| -%>
         server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
@@ -377,20 +349,19 @@ backend http-routers
         <% elsif p("ha_proxy.backend_ssl").downcase == "noverify" then -%>
         ssl verify none <% end -%>
 
-    <% end %>
-# }}}
-
+    <% end -%>
+# }}} 
 # Routed Backends {{{
-<% p('ha_proxy.routed_backend_servers').each do |prefix, data| %>
-<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] %>
+<% p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
+<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
 backend http-routed-backend-<%= prefix_hash %>
     mode http
     balance roundrobin
-    <% if p("ha_proxy.compress_types") != "" %>
+    <% if p("ha_proxy.compress_types") != "" -%>
     compression algo gzip
     compression type <%= p("ha_proxy.compress_types") %>
-    <% end %>
-    <% data["servers"].each_with_index do |ip, index| %>
+    <% end -%>
+    <% data["servers"].each_with_index do |ip, index| -%>
         server node<%= index %> <%= ip %>:<%= data["port"] %> <% if_p("ha_proxy.resolvers") do -%>
         resolvers default <% end -%>
         check inter 1000 <% if data["backend_ssl"] then -%>
@@ -404,9 +375,8 @@ backend http-routed-backend-<%= prefix_hash %>
     <% end -%>
 <% end -%>
 # }}}
-
-# TCP Routing  {{{
-<% if_link("tcp_router") do |tcp_router| %>
+# TCP Routing  {{{ 
+<% if_link("tcp_router") do |tcp_router| -%>
 frontend cf_tcp_routing
   mode tcp
   bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
@@ -415,10 +385,10 @@ backend cf_tcp_routers
   mode tcp
   <% tcp_router.instances.each_with_index do |instance, index| %>
   server node<%= index %> <%= instance.address %> check port 80 inter 1000
-  <% end %>
-<% end %>
+  <% end -%>
+<% end -%>
 
-<%# TCP Backends %>
+# TCP Backends
 <%
 tcp = p("ha_proxy.tcp")
 if_link("tcp_backend") do |tcp_backend|
@@ -429,30 +399,30 @@ if_link("tcp_backend") do |tcp_backend|
     "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port")),
     "health_check_http" => tcp_backend.p("health_check_http", p("ha_proxy.tcp_link_health_check_http", nil))
   }
-end %>
-<% tcp.each do |tcp_proxy| %>
+end -%>
+<% tcp.each do |tcp_proxy| -%>
     frontend tcp-frontend_<%= tcp_proxy["name"]%>
     mode tcp
-<% if tcp_proxy["ssl"] %>
+<% if tcp_proxy["ssl"] -%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tls_bind_options %>
-<% else %>
+<% else -%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= accept_proxy %>
-<% end %>
+<% end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
 
 backend tcp-<%= tcp_proxy["name"] %>
     mode tcp
-<% if tcp_proxy["balance"] %>
+<% if tcp_proxy["balance"] -%>
     balance <%= tcp_proxy["balance"] %>
-<% end %>
+<% end -%>
 
 <%
 backend_port = tcp_proxy["port"]
 if tcp_proxy["backend_port"]
   backend_port = tcp_proxy["backend_port"]
-end %>
+end -%>
 
-  <% tcp_proxy["backend_servers"].each_with_index do |ip, index| %>
+  <% tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
         server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
         resolvers default <% end -%> check inter 1000  <% if tcp_proxy["backend_ssl"] then -%>
            <% if tcp_proxy["backend_ssl"].downcase == "verify" then -%>
@@ -463,7 +433,7 @@ end %>
         <% end -%>
   <% end -%>
 
-  <% if tcp_proxy["health_check_http"] then %>
+  <% if tcp_proxy["health_check_http"] then -%>
 listen health_check_http_tcp-<%= tcp_proxy["name"] %>
     bind :<%= tcp_proxy["health_check_http"] %>
     mode http

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -31,8 +31,11 @@ crt_config = ""
 if_p("ha_proxy.ssl_pem") do
     ssl_enabled = true
     crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
-    if p("ha_proxy.client_ca_file") || p("ha_proxy.client_revocation_list")
-        mutual_tls_enabled = true
+    if_p("ha_proxy.client_ca_file") do
+      mutual_tls_enabled = true
+    end
+    if_p("ha_proxy.client_revocation_list") do
+      mutual_tls_enabled = true
     end
 end
 if_p("ha_proxy.crt_list") do
@@ -350,7 +353,7 @@ backend http-routers
         ssl verify none <% end -%>
 
     <% end -%>
-# }}} 
+# }}}
 # Routed Backends {{{
 <% p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
 <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
@@ -375,7 +378,7 @@ backend http-routed-backend-<%= prefix_hash %>
     <% end -%>
 <% end -%>
 # }}}
-# TCP Routing  {{{ 
+# TCP Routing  {{{
 <% if_link("tcp_router") do |tcp_router| -%>
 frontend cf_tcp_routing
   mode tcp

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -131,7 +131,7 @@ listen stats_<%= proc %>
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-  <%- end %>
+  <%- end -%>
 <% end -%>
 
 <% if p("ha_proxy.enable_health_check_http") %>
@@ -147,7 +147,7 @@ listen health_check_http_url
 resolvers default
     hold valid <%= p("ha_proxy.dns_hold") %>
   <%- resolvers.each do |resolver| -%>
-    nameserver <%= resolver[0] %> <%= resolver[1] %>:53
+    nameserver <%= resolver.keys[0] %> <%= resolver.values[0] %>:53
   <%- end -%>
 <% end -%>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -155,7 +155,7 @@ resolvers default
 # HTTP Frontend {{{
 frontend http-in
     mode http
-    bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %>
+    bind <%= p("ha_proxy.binding_ip") %>:80
     <% if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
@@ -409,7 +409,7 @@ end -%>
 <% if tcp_proxy["ssl"] -%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tls_bind_options %>
 <% else -%>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= accept_proxy %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>
 <% end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -172,13 +172,13 @@ frontend http-in
     default_backend http-routers
 <% if_p("ha_proxy.headers") do |headers| -%>
   <% headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 
 <% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
   <% rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 
@@ -236,13 +236,13 @@ frontend https-in
     default_backend http-routers
 <% if_p("ha_proxy.headers") do |headers| -%>
   <% headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 
 <% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
   <%  rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 
@@ -293,13 +293,13 @@ frontend wss-in
     default_backend http-routers
 <% if_p("ha_proxy.headers") do |headers| -%>
   <% headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 
 <% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
   <% rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
   <% end -%>
 <% end -%>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -1,4 +1,72 @@
 <% require "digest"%>
+<%# Ruby Variables to make the template more readable -%>
+<%
+# Stats Binding Variables {{{
+stat = p("ha_proxy.stats_bind").split(':')
+stat_prefix = stat[0] + ":";
+stat_port = stat[1].to_i;
+# }}}
+# Accept Proxy {{{
+accept_proxy = ""
+if p("ha_proxy.accept_proxy") == true
+    accept_proxy = "accept-proxy"
+end
+# }}}
+# Global SSL Flags {{{
+ssl_flags = "no-sslv3"
+if p("ha_proxy.disable_tls_10")
+	ssl_flags = "#{ssl_flags} no-tlsv10"
+end
+if p("ha_proxy.disable_tls_11")
+	ssl_flags = "#{ssl_flags} no-tlsv11"
+end
+if p("ha_proxy.disable_tls_tickets")
+	ssl_flags = "#{ssl_flags} no-tls-tickets"
+end
+# }}}
+# TLS Bind Options {{{
+mutual_tls_enabled = p("ha_proxy.client_cert")
+ssl_enabled = false
+crt_config = ""
+if_p("ha_proxy.ssl_pem") do
+    ssl_enabled = true
+    crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
+    if p("ha_proxy.client_ca_file") || p("ha_proxy.client_revocation_list")
+        mutual_tls_enabled = true
+    end
+end
+if_p("ha_proxy.crt_list") do
+    if ssl_enabled == true
+        abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
+    end
+    ssl_enabled=true
+    crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"
+    p("ha_proxy.crt_list").each do |crt_entry|
+        if crt_entry.key?("client_ca_file") || crt_entry.key?(" client_revocation_list") || crt_entry["verify"] != "none"
+            mutual_tls_enabled = true
+        end
+    end
+end
+
+client_ca_certs = "/etc/ssl/certs/ca-certificates.crt"
+if_("ha_proxy.client_ca_file") do
+  client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem"
+end
+
+tls_options = "#{crt_config} #{strict_sni}"
+if mutual_tls_enabled == true
+  tls_options = "#{tls_options} ca-file #{client_ca_certs} verify optional"
+  if_p("ha_proxy.client_cert_ignore_err") do |ignore_errs|
+    tls_options = "#{tls_options} crt-ignore-err #{ignore_errs}"
+  end
+  if_p("ha_proxy.client_revocation_list" do
+    tls_options = "#{tls_options} crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem"
+  end
+end
+
+tls_bind_options = "#{accept_proxy} ssl #{tls_options}"
+# }}}
+-%>
 
 global
     log <%= p('ha_proxy.syslog_server') %> syslog <%= p('ha_proxy.log_level') %>
@@ -20,18 +88,6 @@ global
     stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
     <% end %>
     stats timeout 2m
-<%
-    ssl_flags = "no-sslv3"
-    if p("ha_proxy.disable_tls_10")
-        ssl_flags = "#{ssl_flags} no-tlsv10"
-    end
-    if p("ha_proxy.disable_tls_11")
-        ssl_flags = "#{ssl_flags} no-tlsv11"
-    end
-    if p("ha_proxy.disable_tls_tickets")
-        ssl_flags = "#{ssl_flags} no-tls-tickets"
-    end
--%>
     ssl-default-bind-options <%= ssl_flags %>
     ssl-default-bind-ciphers <%= p("ha_proxy.ssl_ciphers") %>
     ssl-default-server-options <%= ssl_flags %>
@@ -52,12 +108,8 @@ defaults
     timeout http-request    <%= (p("ha_proxy.request_timeout").to_f    * 1000).to_i %>ms
     timeout queue           <%= (p("ha_proxy.queue_timeout").to_f      * 1000).to_i %>ms
 
-<% if p("ha_proxy.stats_enable") %>
-  <% stat = p("ha_proxy.stats_bind").split(':');
-     stat_prefix = stat[0] + ":";
-     stat_port = stat[1].to_i;
-   %>
-  <% 1.upto(p("ha_proxy.threads")) do |proc| %>
+<% if p("ha_proxy.stats_enable") -%>
+  <% 1.upto(p("ha_proxy.threads")) do |proc| -%>
 listen stats_<%= proc %>
     bind <%= stat_prefix %><%= stat_port + (proc - 1) %>
     bind-process <%= proc %>
@@ -69,8 +121,8 @@ listen stats_<%= proc %>
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-  <% end %>
-<% end %>
+  <% end -%>
+<% end -%>
 
 <% if p("ha_proxy.enable_health_check_http") %>
 listen health_check_http_url
@@ -101,8 +153,8 @@ end
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
-    bind <%= p("ha_proxy.binding_ip") %>:80
-    <% if_p("ha_proxy.cidr_whitelist") do %>
+    bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %>
+    <% if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
     <% end %>
@@ -164,41 +216,13 @@ end
 
 <%# HTTPS Frontend %>
 
-<%
-ssl_enabled = false
-crt_config = ""
-if_p("ha_proxy.ssl_pem") do
-    ssl_enabled = true
-    crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
-end
-if_p("ha_proxy.crt_list") do
-    if ssl_enabled == true
-        abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
-    end
-    ssl_enabled=true
-    crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"
-end
-%>
-<% if ssl_enabled == true %>
+<% if ssl_enabled == true -%>
+# HTTPS Frontend
 frontend https-in
     mode http
-    <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 accept-proxy ssl <%= crt_config %> <% if p("ha_proxy.strict_sni") %> strict-sni <% end %>
-    <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:443 ssl <%= crt_config %> <% if p("ha_proxy.strict_sni") %> strict-sni <% end %> <% if p("ha_proxy.client_cert") == true -%>
-      <%
-        client_ca_certs = nil
-        if_p("ha_proxy.client_ca_file") { client_ca_certs = "/var/vcap/jobs/haproxy/config/client-ca-certs.pem" }
-        unless client_ca_certs
-          client_ca_certs = "/etc/ssl/certs/ca-certificates.crt"
-        end
-      -%> ca-file <%= client_ca_certs %> verify optional <% if_p("ha_proxy.client_cert_ignore_err") do -%>
-      crt-ignore-err <%= p("ha_proxy.client_cert_ignore_err")-%> <% end -%>
-      <% if_p("ha_proxy.client_revocation_list") do -%>
-        crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem <% end -%>
-      <% end -%>
-    <% end %>
-    <% if_p("ha_proxy.cidr_whitelist") do %>
+    bind <%= p("ha_proxy.binding_ip") %>:443 <%= tls_bind_options %>
+
+    <% if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
     <% end %>
@@ -210,7 +234,7 @@ frontend https-in
     tcp-request content reject
     <% end %>
 
-    <% if p("ha_proxy.client_cert") == true %>
+    <% if mutual_tls_enabled == true -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
     <% end %>
 
@@ -262,11 +286,27 @@ end
 <% if p("ha_proxy.enable_4443") == true %>
 frontend wss-in
     mode http
-    <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:4443 accept-proxy ssl <%= crt_config %>
-    <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:4443 ssl <%= crt_config %>
-    <% end %>
+    bind <%= p("ha_proxy.binding_ip") %>:4443 <%= tls_bind_options %>
+    <% if_p("ha_proxy.cidr_whitelist") do -%>
+    acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
+    tcp-request content accept if whitelist
+    <% end -%>
+    <% if_p("ha_proxy.cidr_blacklist") do -%>
+    acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
+    tcp-request content reject if blacklist
+    <% end -%>
+    <% if p("ha_proxy.block_all") then -%>
+    tcp-request content reject
+    <% end -%>
+
+    <% if mutual_tls_enabled == true -%>
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
+    <% end -%>
+
+    <% if p("ha_proxy.hsts_enable") -%>
+    http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
+    <% end -%>
+    capture request header Host len 256
     default_backend http-routers
 <%
 if_p("ha_proxy.headers") do |headers|
@@ -278,6 +318,15 @@ if_p("ha_proxy.headers") do |headers|
 end
 %>
 
+<%
+if_p("ha_proxy.rsp_headers") do |rsp_headers|
+  rsp_headers.each do |rsp_header, value|
+-%>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+-%>
 
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
@@ -292,11 +341,12 @@ end
   acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
   use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
 <% end %>
-    reqadd X-Forwarded-Proto:\ https
-
-<%# Default Backend %>
-
+    acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
+    reqadd X-Forwarded-Proto:\ https if ! xfp_exists
+# }}}
 <% end %>
+
+# Default Backend {{{
 backend http-routers
     mode http
     balance roundrobin
@@ -328,9 +378,9 @@ backend http-routers
         ssl verify none <% end -%>
 
     <% end %>
+# }}}
 
-<%# Routed Backends %>
-
+# Routed Backends {{{
 <% p('ha_proxy.routed_backend_servers').each do |prefix, data| %>
 <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] %>
 backend http-routed-backend-<%= prefix_hash %>
@@ -353,8 +403,9 @@ backend http-routed-backend-<%= prefix_hash %>
 
     <% end -%>
 <% end -%>
+# }}}
 
-<%# CF TCP Routing %>
+# TCP Routing  {{{
 <% if_link("tcp_router") do |tcp_router| %>
 frontend cf_tcp_routing
   mode tcp
@@ -383,13 +434,9 @@ end %>
     frontend tcp-frontend_<%= tcp_proxy["name"]%>
     mode tcp
 <% if tcp_proxy["ssl"] %>
-    <% if p("ha_proxy.accept_proxy") %>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> accept-proxy ssl <%= crt_config %>
-    <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> ssl <%= crt_config %>
-    <% end %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tls_bind_options %>
 <% else %>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= accept_proxy %>
 <% end %>
     default_backend tcp-<%= tcp_proxy["name"] %>
 
@@ -425,3 +472,4 @@ listen health_check_http_tcp-<%= tcp_proxy["name"] %>
     monitor fail if tcp-<%= tcp_proxy["name"] %>-routers_down
   <% end -%>
 <% end -%>
+# }}}

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -1,4 +1,4 @@
-<% require "digest"%>
+<% require "digest" -%>
 <%# Ruby Variables to make the template more readable -%>
 <%
 # Stats Binding Variables {{{
@@ -9,19 +9,19 @@ stat_port = stat[1].to_i;
 # Accept Proxy {{{
 accept_proxy = ""
 if p("ha_proxy.accept_proxy")
-    accept_proxy = "accept-proxy"
+  accept_proxy = "accept-proxy"
 end
 # }}}
 # Global SSL Flags {{{
 ssl_flags = "no-sslv3"
 if p("ha_proxy.disable_tls_10")
-	ssl_flags = "#{ssl_flags} no-tlsv10"
+  ssl_flags = "#{ssl_flags} no-tlsv10"
 end
 if p("ha_proxy.disable_tls_11")
-	ssl_flags = "#{ssl_flags} no-tlsv11"
+  ssl_flags = "#{ssl_flags} no-tlsv11"
 end
 if p("ha_proxy.disable_tls_tickets")
-	ssl_flags = "#{ssl_flags} no-tls-tickets"
+  ssl_flags = "#{ssl_flags} no-tls-tickets"
 end
 # }}}
 # TLS Bind Options {{{
@@ -29,26 +29,26 @@ mutual_tls_enabled = p("ha_proxy.client_cert")
 ssl_enabled = false
 crt_config = ""
 if_p("ha_proxy.ssl_pem") do
-    ssl_enabled = true
-    crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
-    if_p("ha_proxy.client_ca_file") do
-      mutual_tls_enabled = true
-    end
-    if_p("ha_proxy.client_revocation_list") do
-      mutual_tls_enabled = true
-    end
+  ssl_enabled = true
+  crt_config="crt /var/vcap/jobs/haproxy/config/ssl"
+  if_p("ha_proxy.client_ca_file") do
+    mutual_tls_enabled = true
+  end
+  if_p("ha_proxy.client_revocation_list") do
+    mutual_tls_enabled = true
+  end
 end
 if_p("ha_proxy.crt_list") do
-    if ssl_enabled
-        abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
+  if ssl_enabled
+    abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
+  end
+  ssl_enabled=true
+  crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"
+  p("ha_proxy.crt_list").each do |crt_entry|
+    if crt_entry.key?("client_ca_file") || crt_entry.key?(" client_revocation_list") || crt_entry["verify"] != "none"
+      mutual_tls_enabled = true
     end
-    ssl_enabled=true
-    crt_config="crt-list /var/vcap/jobs/haproxy/config/ssl/crt-list"
-    p("ha_proxy.crt_list").each do |crt_entry|
-        if crt_entry.key?("client_ca_file") || crt_entry.key?(" client_revocation_list") || crt_entry["verify"] != "none"
-            mutual_tls_enabled = true
-        end
-    end
+  end
 end
 
 client_ca_certs = "/etc/ssl/certs/ca-certificates.crt"
@@ -81,22 +81,22 @@ tls_bind_options = "#{accept_proxy} ssl #{tls_options}"
 global
     log <%= p('ha_proxy.syslog_server') %> syslog <%= p('ha_proxy.log_level') %>
     daemon
-    <% if p("ha_proxy.threads") > 1 -%>
+  <%- if p("ha_proxy.threads") > 1 -%>
     nbproc <%= p("ha_proxy.threads") %>
-    <% end -%>
+  <%- end -%>
     user vcap
     group vcap
     maxconn 64000
     spread-checks 4
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
     tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
-    <% if p("ha_proxy.threads") > 1 -%>
-      <% 1.upto(p("ha_proxy.threads")) do |proc| -%>
+  <%- if p("ha_proxy.threads") > 1 -%>
+    <%- 1.upto(p("ha_proxy.threads")) do |proc| -%>
     stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 level admin process <%= proc%>
-      <% end -%>
-    <% else -%>
+    <%- end -%>
+  <%- else -%>
     stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
-    <% end -%>
+  <%- end -%>
     stats timeout 2m
     ssl-default-bind-options <%= ssl_flags %>
     ssl-default-bind-ciphers <%= p("ha_proxy.ssl_ciphers") %>
@@ -119,7 +119,7 @@ defaults
     timeout queue           <%= (p("ha_proxy.queue_timeout").to_f      * 1000).to_i %>ms
 
 <% if p("ha_proxy.stats_enable") -%>
-  <% 1.upto(p("ha_proxy.threads")) do |proc| -%>
+  <%- 1.upto(p("ha_proxy.threads")) do |proc| %>
 listen stats_<%= proc %>
     bind <%= stat_prefix %><%= stat_port + (proc - 1) %>
     bind-process <%= proc %>
@@ -131,7 +131,7 @@ listen stats_<%= proc %>
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-  <% end -%>
+  <%- end %>
 <% end -%>
 
 <% if p("ha_proxy.enable_health_check_http") %>
@@ -141,14 +141,14 @@ listen health_check_http_url
     monitor-uri /health
     acl http-routers_down nbsrv(http-routers) eq 0
     monitor fail if http-routers_down
-<% end %>
+<% end -%>
 
 <% if_p("ha_proxy.resolvers") do |resolvers| -%>
 resolvers default
     hold valid <%= p("ha_proxy.dns_hold") %>
-  <% resolvers.each do |resolver| %>
-    nameserver <%= resolver.keys[0] %> <%= resolver.values[0] %>:53
-  <% end -%>
+  <%- resolvers.each do |resolver| -%>
+    nameserver <%= resolver[0] %> <%= resolver[1] %>:53
+  <%- end -%>
 <% end -%>
 
 <% unless p("ha_proxy.disable_http") -%>
@@ -156,55 +156,50 @@ resolvers default
 frontend http-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:80
-    <% if_p("ha_proxy.cidr_whitelist") do -%>
+  <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
-    <% end -%>
-    <% if_p("ha_proxy.cidr_blacklist") do -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
-    <% end -%>
-    <% if p("ha_proxy.block_all") then -%>
+  <%- end -%>
+  <%- if p("ha_proxy.block_all") then -%>
     tcp-request content reject
-    <% end -%>
-
+  <%- end -%>
     capture request header Host len 256
     default_backend http-routers
-<% if_p("ha_proxy.headers") do |headers| -%>
-  <% headers.each do |header, value| -%>
+  <%- if_p("ha_proxy.headers") do |headers| -%>
+    <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
-  <% rsp_headers.each do |rsp_header, value| -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+    <%- rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if p("ha_proxy.internal_only_domains").size > 0 -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-  <% p("ha_proxy.internal_only_domains").each do |domain| -%>
+    <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-  <% end -%>
+    <%- end -%>
     http-request deny if internal !private
-<% end -%>
-
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
-    <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+  <%- end -%>
+  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end -%>
+  <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ http if ! xfp_exists
-
-<% if p("ha_proxy.https_redirect_all") -%>
+  <%- if p("ha_proxy.https_redirect_all") -%>
     redirect scheme https code 301 if !{ ssl_fc }
-<% end -%>
-<% unless p("ha_proxy.https_redirect_all") -%>
+  <%- end -%>
+  <%- unless p("ha_proxy.https_redirect_all") -%>
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
-<% end -%>
+  <%- end -%>
 # }}}
 <% end -%>
 
@@ -213,55 +208,49 @@ frontend http-in
 frontend https-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= tls_bind_options %>
-    <% if_p("ha_proxy.cidr_whitelist") do -%>
+  <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
-    <% end -%>
-    <% if_p("ha_proxy.cidr_blacklist") do -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
-    <% end -%>
-    <% if p("ha_proxy.block_all") then -%>
+  <%- end -%>
+  <%- if p("ha_proxy.block_all") then -%>
     tcp-request content reject
-    <% end -%>
-
-    <% if mutual_tls_enabled -%>
+  <%- end -%>
+  <%- if mutual_tls_enabled -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
-    <% end -%>
-
-    <% if p("ha_proxy.hsts_enable") -%>
+  <%- end -%>
+  <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
-    <% end -%>
+  <%- end -%>
     capture request header Host len 256
     default_backend http-routers
-<% if_p("ha_proxy.headers") do |headers| -%>
-  <% headers.each do |header, value| -%>
+  <%- if_p("ha_proxy.headers") do |headers| -%>
+    <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
-  <%  rsp_headers.each do |rsp_header, value| -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+    <%- rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if p("ha_proxy.internal_only_domains").size > 0 -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-<% p("ha_proxy.internal_only_domains").each do |domain| -%>
+    <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-<% end -%>
+    <%- end -%>
     http-request deny if internal !private
-<% end -%>
-
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
-  <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+  <%- end -%>
+  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end -%>
+  <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
-
 # }}}
 <% end -%>
 
@@ -270,52 +259,47 @@ frontend https-in
 frontend wss-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= tls_bind_options %>
-    <% if_p("ha_proxy.cidr_whitelist") do -%>
+  <%- if_p("ha_proxy.cidr_whitelist") do -%>
     acl whitelist src -f /var/vcap/jobs/haproxy/config/whitelist_cidrs.txt
     tcp-request content accept if whitelist
-    <% end -%>
-    <% if_p("ha_proxy.cidr_blacklist") do -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.cidr_blacklist") do -%>
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
-    <% end -%>
-    <% if p("ha_proxy.block_all") then -%>
+  <%- end -%>
+  <%- if p("ha_proxy.block_all") then -%>
     tcp-request content reject
-    <% end -%>
-
-    <% if mutual_tls_enabled -%>
+  <%- end -%>
+  <%- if mutual_tls_enabled -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
-    <% end -%>
-
-    <% if p("ha_proxy.hsts_enable") -%>
+  <%- end -%>
+  <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
-    <% end -%>
+  <%- end -%>
     capture request header Host len 256
     default_backend http-routers
-<% if_p("ha_proxy.headers") do |headers| -%>
-  <% headers.each do |header, value| -%>
+  <%- if_p("ha_proxy.headers") do |headers| -%>
+    <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
-  <% rsp_headers.each do |rsp_header, value| -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
+    <%- rsp_headers.each do |rsp_header, value| -%>
     rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
-  <% end -%>
-<% end -%>
-
-<% if p("ha_proxy.internal_only_domains").size > 0 -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
-<% p("ha_proxy.internal_only_domains").each do |domain| -%>
+    <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
-<% end -%>
+    <%- end -%>
     http-request deny if internal !private
-<% end -%>
-
-<% p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
-    <% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+  <%- end -%>
+  <%- p('ha_proxy.routed_backend_servers').keys.each do |prefix| -%>
+    <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
     acl routed_backend_<%= prefix_hash %> path_beg <%= prefix %>
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
-<% end -%>
+  <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
 # }}}
@@ -325,70 +309,89 @@ frontend wss-in
 backend http-routers
     mode http
     balance roundrobin
-    <% if p("ha_proxy.compress_types") != "" -%>
+  <%- if p("ha_proxy.compress_types") != "" -%>
     compression algo gzip
     compression type <%= p("ha_proxy.compress_types") %>
-    <% end -%>
-
-    <%
-    backend_servers = []
-    backend_port = nil
-    if_link("http_backend") do |backend|
-        backend_servers = backend.instances.map(&:address)
-        backend_port = backend.p("port", p("ha_proxy.backend_port"))
-    end.else_if_p("ha_proxy.backend_servers") do |servers|
-        backend_servers = servers
-        backend_port = p("ha_proxy.backend_port")
+  <%- end -%>
+<%
+  backend_servers = []
+  backend_port = nil
+  if_link("http_backend") do |backend|
+    backend_servers = backend.instances.map(&:address)
+    backend_port = backend.p("port", p("ha_proxy.backend_port"))
+  end.else_if_p("ha_proxy.backend_servers") do |servers|
+    backend_servers = servers
+    backend_port = p("ha_proxy.backend_port")
+  end
+  resolvers = ""
+  if_p("ha_proxy.resolvers") do
+    resolvers = "resolvers default "
+  end
+  backend_crt = ""
+  if_p("ha_proxy.backend_crt") do
+    backend_crt = "crt /var/vcap/jobs/haproxy/config/backend-crt.pem "
+  end
+  backend_ssl = ""
+  if p("ha_proxy.backend_ssl").downcase == "verify" then
+    backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
+    if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname |
+      backend_ssl += "verifyhost #{verify_hostname} "
     end
-    -%>
-
-    <% backend_servers.each_with_index do |ip, index| -%>
-        server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
-        resolvers default <% end -%>
-        <% if_p("ha_proxy.backend_crt") do -%> crt  /var/vcap/jobs/haproxy/config/backend-crt.pem <% end -%>
-        check inter 1000 <% if p("ha_proxy.backend_ssl").downcase == "verify" then -%>
-        ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem <% if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname | -%>
-        verifyhost <%= verify_hostname %> <% end -%>
-        <% elsif p("ha_proxy.backend_ssl").downcase == "noverify" then -%>
-        ssl verify none <% end -%>
-
-    <% end -%>
+  elsif p("ha_proxy.backend_ssl").downcase == "noverify" then
+    backend_ssl = "ssl verify none "
+  end
+-%>
+  <%- backend_servers.each_with_index do |ip, index| -%>
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= backend_ssl %>
+  <%- end -%>
 # }}}
+
 # Routed Backends {{{
 <% p('ha_proxy.routed_backend_servers').each do |prefix, data| -%>
-<% prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
+  <%- prefix_hash = (Digest::SHA256.hexdigest prefix.to_s)[0..5] -%>
 backend http-routed-backend-<%= prefix_hash %>
     mode http
     balance roundrobin
-    <% if p("ha_proxy.compress_types") != "" -%>
+  <%- if p("ha_proxy.compress_types") != "" -%>
     compression algo gzip
     compression type <%= p("ha_proxy.compress_types") %>
-    <% end -%>
-    <% data["servers"].each_with_index do |ip, index| -%>
-        server node<%= index %> <%= ip %>:<%= data["port"] %> <% if_p("ha_proxy.resolvers") do -%>
-        resolvers default <% end -%>
-        check inter 1000 <% if data["backend_ssl"] then -%>
-           <% if data["backend_ssl"].downcase == "verify" then -%>
-             ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem <% if data["backend_verifyhost"] then -%>
-             verifyhost <%= data["backend_verifyhost"] %> <% end -%>
-           <% elsif data["backend_ssl"].downcase == "noverify" then -%>
-             ssl verify none <% end -%>
-        <% end -%>
-
-    <% end -%>
+  <%- end -%>
+<%
+  resolvers = ""
+  if_p("ha_proxy.resolvers") do
+    resolvers = "resolvers default "
+  end
+  backend_ssl = ""
+  if data["backend_ssl"] then
+    if data["backend_ssl"].downcase == "verify" then
+      backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
+      if data["backend_verifyhost"] then
+        backend_ssl += "verifyhost #{data["backend_verifyhost"]} "
+      end
+    elsif data["backend_ssl"].downcase == "noverify" then
+      backend_ssl = "ssl verify none "
+    end
+  end
+-%>
+  <%- data["servers"].each_with_index do |ip, index| -%>
+    server node<%= index %> <%= ip %>:<%= data["port"] %> <%= resolvers -%>check inter 1000 <%= backend_ssl %>
+  <%- end -%>
 <% end -%>
 # }}}
+
 # TCP Routing  {{{
 <% if_link("tcp_router") do |tcp_router| -%>
+
 frontend cf_tcp_routing
-  mode tcp
-  bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
-  default_backend cf_tcp_routers
+    mode tcp
+    bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
+    default_backend cf_tcp_routers
+
 backend cf_tcp_routers
-  mode tcp
-  <% tcp_router.instances.each_with_index do |instance, index| %>
-  server node<%= index %> <%= instance.address %> check port 80 inter 1000
-  <% end -%>
+    mode tcp
+  <%- tcp_router.instances.each_with_index do |instance, index| -%>
+    server node<%= index %> <%= instance.address %> check port 80 inter 1000
+  <%- end -%>
 <% end -%>
 
 # TCP Backends
@@ -404,45 +407,53 @@ if_link("tcp_backend") do |tcp_backend|
   }
 end -%>
 <% tcp.each do |tcp_proxy| -%>
-    frontend tcp-frontend_<%= tcp_proxy["name"]%>
+frontend tcp-frontend_<%= tcp_proxy["name"]%>
     mode tcp
-<% if tcp_proxy["ssl"] -%>
+  <%- if tcp_proxy["ssl"] -%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tls_bind_options %>
-<% else -%>
+  <%- else -%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>
-<% end -%>
+  <%- end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
 
 backend tcp-<%= tcp_proxy["name"] %>
     mode tcp
-<% if tcp_proxy["balance"] -%>
+  <%- if tcp_proxy["balance"] -%>
     balance <%= tcp_proxy["balance"] %>
-<% end -%>
-
+  <%- end -%>
 <%
-backend_port = tcp_proxy["port"]
-if tcp_proxy["backend_port"]
-  backend_port = tcp_proxy["backend_port"]
-end -%>
+  backend_port = tcp_proxy["port"]
+  if tcp_proxy["backend_port"]
+    backend_port = tcp_proxy["backend_port"]
+  end
+  resolvers = ""
+  if_p("ha_proxy.resolvers") do
+    resolvers = "resolvers default "
+  end
+  backend_ssl = ""
+  if tcp_proxy["backend_ssl"] then
+    if tcp_proxy["backend_ssl"].downcase == "verify" then
+      backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
+      if tcp_proxy["backend_verifyhost"] then
+        backend_ssl += "verifyhost #{tcp_proxy["backend_verifyhost"]} "
+      end
+    elsif tcp_proxy["backend_ssl"].downcase == "noverify" then
+      backend_ssl = "ssl verify none "
+    end
+  end
+-%>
+  <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %>
+  <%- end -%>
 
-  <% tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-        server node<%= index %> <%= ip %>:<%= backend_port %> <% if_p("ha_proxy.resolvers") do -%>
-        resolvers default <% end -%> check inter 1000  <% if tcp_proxy["backend_ssl"] then -%>
-           <% if tcp_proxy["backend_ssl"].downcase == "verify" then -%>
-             ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem <% if tcp_proxy["backend_verifyhost"] then -%>
-             verifyhost <%= tcp_proxy["backend_verifyhost"] %> <% end -%>
-           <% elsif tcp_proxy["backend_ssl"].downcase == "noverify" then -%>
-             ssl verify none <% end -%>
-        <% end -%>
-  <% end -%>
-
-  <% if tcp_proxy["health_check_http"] then -%>
+  <%- if tcp_proxy["health_check_http"] then -%>
 listen health_check_http_tcp-<%= tcp_proxy["name"] %>
     bind :<%= tcp_proxy["health_check_http"] %>
     mode http
     monitor-uri /health
     acl tcp-<%= tcp_proxy["name"] %>-routers_down nbsrv(tcp-<%= tcp_proxy["name"] %>) eq 0
     monitor fail if tcp-<%= tcp_proxy["name"] %>-routers_down
-  <% end -%>
+  <%- end -%>
 <% end -%>
+
 # }}}

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -8,7 +8,7 @@ stat_port = stat[1].to_i;
 # }}}
 # Accept Proxy {{{
 accept_proxy = ""
-if p("ha_proxy.accept_proxy") == true
+if p("ha_proxy.accept_proxy")
     accept_proxy = "accept-proxy"
 end
 # }}}
@@ -39,7 +39,7 @@ if_p("ha_proxy.ssl_pem") do
     end
 end
 if_p("ha_proxy.crt_list") do
-    if ssl_enabled == true
+    if ssl_enabled
         abort("Conflicting configuration. Please configure either 'ssl_pem' OR 'crt_list', but not both")
     end
     ssl_enabled=true
@@ -58,13 +58,13 @@ end
 
 strict_sni = ""
 if_p("ha_proxy.strict_sni") do |sni|
-  if sni == true
+  if sni
     strict_sni = "strict-sni"
   end
 end
 
 tls_options = "#{crt_config} #{strict_sni}"
-if mutual_tls_enabled == true
+if mutual_tls_enabled
   tls_options = "#{tls_options} ca-file #{client_ca_certs} verify optional"
   if_p("ha_proxy.client_cert_ignore_err") do |ignore_errs|
     tls_options = "#{tls_options} crt-ignore-err #{ignore_errs}"
@@ -198,17 +198,17 @@ frontend http-in
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ http if ! xfp_exists
 
-<% if p("ha_proxy.https_redirect_all") == true -%>
+<% if p("ha_proxy.https_redirect_all") -%>
     redirect scheme https code 301 if !{ ssl_fc }
 <% end -%>
-<% unless p("ha_proxy.https_redirect_all") == true -%>
+<% unless p("ha_proxy.https_redirect_all") -%>
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
 <% end -%>
 # }}}
 <% end -%>
 
-<% if ssl_enabled == true -%>
+<% if ssl_enabled -%>
 # HTTPS Frontend {{{
 frontend https-in
     mode http
@@ -225,7 +225,7 @@ frontend https-in
     tcp-request content reject
     <% end -%>
 
-    <% if mutual_tls_enabled == true -%>
+    <% if mutual_tls_enabled -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
     <% end -%>
 
@@ -265,7 +265,7 @@ frontend https-in
 # }}}
 <% end -%>
 
-<% if p("ha_proxy.enable_4443") == true -%>
+<% if p("ha_proxy.enable_4443") -%>
 # HTTPS Websockets Frontend {{{
 frontend wss-in
     mode http
@@ -282,7 +282,7 @@ frontend wss-in
     tcp-request content reject
     <% end -%>
 
-    <% if mutual_tls_enabled == true -%>
+    <% if mutual_tls_enabled -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
     <% end -%>
 


### PR DESCRIPTION
- The HTTP frontend now supports accept-proxy.
- Bugs where accept-proxy was not honored during mutual TLS have been
resolved
- `ha_proxy.client_cert` is no longer required to enable TLS. It is
   still honored to enable mutual tls, but the boshrelease will also
   use the presence of the following parameters to enable mutual TLS:

   - `ha_proxy.client_ca_file`
   - `ha_proxy.client_revocation_list`
   - `ha_proxy.crt_list.<i>.client_ca_file`
   - `ha_proxy.crt_list.<i>.client_revocation_list`
   - `ha_proxy.crt_list.<i>.verify` - only when value is not "none"

- The following options are now honored in the `:4443` backend:
  - `ha_proxy.cidr_whitelist`
  - `ha_proxy.cidr_blacklist`
  - `ha_proxy.block_all`
  - `ha_proxy.hsts_*`
  - `ha_proxy.rsp_headers`

- The X-Forwarded-Client_Cert now is set for requests in the `:4443`
  backend.

- The X-Forwarded-Proto header behavior in the `:4443` backend now
  matches the behavior in the `:443` backend

Fixes #95