### PR TITLE
Add configuration for http-request deny conditions

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -343,3 +343,13 @@ properties:
   ha_proxy.tcp_routing.port_range:
     description: "A range of ports for haproxy to listen on to enable CF TCP Routing. Used only if 'tcp_router' link is present."
     default: 1024-1123
+
+  ha_proxy.http_request_deny_conditions:
+      description: "List of conditions to block http requests. Each condition consists of multiple rules combined with the AND operator"
+      example:
+        http_request_deny_conditions:
+        - condition:
+          - acl_name: block_host
+            acl_rule: "hdr_beg(host) -i login"
+          - acl_name: block_reset_password_url
+            acl_rule: "path_beg,url_dec -m beg -i /reset_password"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -173,6 +173,16 @@ frontend http-in
   <%- end -%>
     capture request header Host len 256
     default_backend http-routers
+  <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>
+    <%- conditions.each do |condition| -%>
+      <%- acl_names="" -%>
+      <%- condition["condition"].each do |acl| -%>
+    acl <%= acl["acl_name"] %> <%= acl["acl_rule"] %>
+      <%- acl_names=acl_names+acl["acl_name"]+" " -%>
+      <%- end -%>
+    http-request deny if <%= acl_names %>
+    <%- end -%>
+  <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
@@ -231,6 +241,16 @@ frontend https-in
   <%- end -%>
     capture request header Host len 256
     default_backend http-routers
+  <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>
+    <%- conditions.each do |condition| -%>
+      <%- acl_names="" -%>
+      <%- condition["condition"].each do |acl| -%>
+    acl <%= acl["acl_name"] %> <%= acl["acl_rule"] %>
+      <%- acl_names=acl_names+acl["acl_name"]+" " -%>
+      <%- end -%>
+    http-request deny if <%= acl_names %>
+    <%- end -%>
+  <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
@@ -282,6 +302,16 @@ frontend wss-in
   <%- end -%>
     capture request header Host len 256
     default_backend http-routers
+  <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>
+    <%- conditions.each do |condition| -%>
+      <%- acl_names="" -%>
+      <%- condition["condition"].each do |acl| -%>
+    acl <%= acl["acl_name"] %> <%= acl["acl_rule"] %>
+      <%- acl_names=acl_names+acl["acl_name"]+" " -%>
+      <%- end -%>
+    http-request deny if <%= acl_names %>
+    <%- end -%>
+  <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>


### PR DESCRIPTION
This allows for blocking http-requests according to
http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#7.2

This commit supports conditions consisting of multiple rules
combined with the AND operator. The OR operator and negation
are note yest supported.