### PR TITLE
Make health check port configurable

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -131,6 +131,9 @@ properties:
   ha_proxy.enable_health_check_http:
     description: "Optionally enable http health-check on `haproxy_ip:8080/health`. It shows `200 OK` if >0 backend servers are up."
     default: false
+  ha_proxy.health_check_port:
+    description: "port for http health-check"
+    default: 8080  
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"
     default: false

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -140,7 +140,7 @@ listen stats_<%= proc %>
 
 <% if p("ha_proxy.enable_health_check_http") %>
 listen health_check_http_url
-    bind :8080
+    bind :<%= p("ha_proxy.health_check_port") %>
     mode http
     monitor-uri /health
     acl http-routers_down nbsrv(http-routers) eq 0


### PR DESCRIPTION
I have a use case where port 8080 is already taken by another process that I cannot change. So I need to be able to configure the health check port of ha proxy.

I tested this change and it was working well on my GCP environment