### PR TITLE
Only add X-Forwarded-Client-Cert header if client certificate is present

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -234,7 +234,7 @@ frontend https-in
     tcp-request content reject
   <%- end -%>
   <%- if mutual_tls_enabled -%>
-    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
@@ -295,7 +295,7 @@ frontend wss-in
     tcp-request content reject
   <%- end -%>
   <%- if mutual_tls_enabled -%>
-    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>


### PR DESCRIPTION
This change only appends the `X-Forwarded-Client-Cert` header in case the current SSL session uses a client certificate. See http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#7.3.4-ssl_c_used

Previously an empty header field was added which can cause problems with some applications.
```
X-Forwarded-Client-Cert: ""
```