### PR TITLE
Typo path packages

### DIFF
--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -5,7 +5,7 @@ set -e
 
 source /var/vcap/jobs/haproxy/helpers/ctl_setup.sh 'haproxy'
 PATH=/var/vcap/packages/haproxy/bin:$PATH
-export PATH=$PATH:/var/vcap/packges/ttar/bin
+export PATH=$PATH:/var/vcap/packages/ttar/bin
 
 NAME=haproxy
 DAEMON=$(which haproxy)


### PR DESCRIPTION
Should read /var/vcap/packages/ttar/bin/ instead of /var/vcap/packges/ttar/bin/