### PR TITLE
Add option to forward or sanitize X-Forwarded-Client-Cert header

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -133,7 +133,7 @@ properties:
     default: false
   ha_proxy.health_check_port:
     description: "port for http health-check"
-    default: 8080  
+    default: 8080
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"
     default: false
@@ -265,6 +265,24 @@ properties:
   ha_proxy.client_cert:
     description: "Enable haproxy mutual auth and produce a client cert header (X-Forwarded-Client-Cert) to offload mutual ssl client certificate to backend"
     default: false
+
+  ha_proxy.forwarded_client_cert:
+    description: |
+      This option lets you decide how to handle the X-Forwarded-Client-Cert (XFCC) http header on any https frontend.
+      On http frontends the `always_forward_only` option is active by default and can't be changed.
+      On https frontends your options are (ordered from least to most secure):
+      - always_forward_only:
+          Least secure option. Always forward the XFCC header in the request, regardless of whether the client connection is mTLS.
+          Use this value when your load balancer is forwarding the client certificate and requests are not forwarded to HAProxy over mTLS.
+          In the case where the connection between load balancer and HAProxy is mTLS, the client certificate received by HAProxy in the mTLS handshake will not be forwarded.
+      - forward_only:
+          Secure version of `always_forward_only`. Forward the XFCC header received from the client only when the client connection is mTLS.
+          The client certificate received by HAProxy in the mTLS handshake will not be forwarded.
+      - sanitize_set:
+          Most secure option. Strip any instances of XFCC headers from the client request.
+          When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in this header.
+          Values will be base64 encoded PEM. Use this value when HAProxy is the first component to terminate TLS.
+    default: sanitize_set
 
   ha_proxy.client_ca_file:
     description: "path for CA certs to validate client certificate"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -234,6 +234,7 @@ frontend https-in
     tcp-request content reject
   <%- end -%>
   <%- if mutual_tls_enabled -%>
+    http-request del-header X-Forwarded-Client-Cert
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
@@ -295,6 +296,7 @@ frontend wss-in
     tcp-request content reject
   <%- end -%>
   <%- if mutual_tls_enabled -%>
+    http-request del-header X-Forwarded-Client-Cert
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -80,6 +80,22 @@ end
 
 tls_bind_options = "ssl #{tls_options}"
 # }}}
+# X-Forwarded-Client-Cert (XFCC) Option {{{
+xfcc_forward_only = false
+xfcc_sanitize_set = false
+
+forwarded_client_cert_option = p("ha_proxy.forwarded_client_cert").downcase
+case forwarded_client_cert_option
+when "always_forward_only"
+  # NOP
+when "forward_only"
+  xfcc_forward_only = true
+when "sanitize_set"
+  xfcc_sanitize_set = true
+else
+  abort("Unkown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set'")
+end
+# }}}
 -%>
 
 global
@@ -233,9 +249,13 @@ frontend https-in
   <%- if p("ha_proxy.block_all") then -%>
     tcp-request content reject
   <%- end -%>
-  <%- if mutual_tls_enabled -%>
+  <%- if xfcc_forward_only then -%>
+    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled then %> if ! { ssl_c_used }<% end %>
+  <%- elsif xfcc_sanitize_set then -%>
     http-request del-header X-Forwarded-Client-Cert
+    <%- if mutual_tls_enabled then -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
+    <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
@@ -295,9 +315,13 @@ frontend wss-in
   <%- if p("ha_proxy.block_all") then -%>
     tcp-request content reject
   <%- end -%>
-  <%- if mutual_tls_enabled -%>
+  <%- if xfcc_forward_only then -%>
+    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled then %> if ! { ssl_c_used }<% end %>
+  <%- elsif xfcc_sanitize_set then -%>
     http-request del-header X-Forwarded-Client-Cert
+    <%- if mutual_tls_enabled then -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
+    <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>


### PR DESCRIPTION
Adds the new option `forwarded_client_cert` to the haproxy boshrelease. This option lets you decide how the  X-Forwarded-Client-Cert (XFCC) header is handled. The options are similar to the ones from the gorouter (https://github.com/cloudfoundry-incubator/routing-release/blob/develop/jobs/gorouter/spec#L115-L125).

The related Issue #86 should be fixed.

From the new spec file:

`ha_proxy.forwarded_client_cert`:
      This option lets you decide how to handle the X-Forwarded-Client-Cert (XFCC) http header on any https frontend. On http frontends the `always_forward_only` option is active by default and can't be changed. On https frontends your options are (ordered from least to most secure):
 - `always_forward_only`:
          Least secure option. Always forward the XFCC header in the request, regardless of whether the client connection is mTLS. Use this value when your load balancer is forwarding the client certificate and requests are not forwarded to HAProxy over mTLS. In the case where the connection between load balancer and HAProxy is mTLS, the client certificate received by HAProxy in the mTLS handshake will not be forwarded.
- `forward_only`:
          Secure version of `always_forward_only`. Forward the XFCC header received from the client only when the client connection is mTLS. The client certificate received by HAProxy in the mTLS handshake will not be forwarded.
- `sanitize_set`:
          Most secure option. Strip any instances of XFCC headers from the client request. When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in this header. Values will be base64 encoded PEM. Use this value when HAProxy is the first component to terminate TLS.
 
The **default** is set to `sanitize_set`. 

:warning: Please be aware that this pull request changes the default behaviour of the haproxy-boshrelease for configurations that use https but have not configured client authentication. Previously the XFCC header has been forwarded in this case, but it will be removed per default with this change. We decided to go with this change as it is more secure and align with the available options from the gorouter release.