### PR TITLE
bugfix missing bpm release and multiple haproxy version releases

### DIFF
--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -36,9 +36,9 @@ stemcells:
 
 releases:
 - name: haproxy
-  version: 9.3.0
-  url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v9.3.0/haproxy-9.3.0.tgz
-- name: haproxy
   version: 9.4.0
   url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v9.4.0/haproxy-9.4.0.tgz
   sha1: e873611c1c24a0044130319c3b2799b7068ff734
+- name: bpm
+  version: 1.0.0
+  url: https://github.com/cloudfoundry-incubator/bpm-release/releases/download/v1.0.0/bpm-release-1.0.0.tgz


### PR DESCRIPTION
This PR contains 2 fixes:

The bpm release was missing
There is now only one (v9.4.0) haproxy release definied