### PR TITLE
Allow configuring dont_track_primary for keepalived

### DIFF
--- a/jobs/keepalived/spec
+++ b/jobs/keepalived/spec
@@ -29,5 +29,8 @@ properties:
     description: interface keepalived will use to mount the VIP. If set to 'auto', uses the default interface on the VM
     default: auto
   keepalived.virtual_router_id:                
-    description : Specifies the VRRP virtual router identifier (VRID)(numerical from 1 to 255). A unique VRID value is needed for each VRRP cluster
+    description: Specifies the VRRP virtual router identifier (VRID)(numerical from 1 to 255). A unique VRID value is needed for each VRRP cluster
     default: 1
+  keepalived.dont_track_primary:
+    description: Ignore VRRP interface faults
+    default: false

--- a/jobs/keepalived/templates/keepalived.config.erb
+++ b/jobs/keepalived/templates/keepalived.config.erb
@@ -1,6 +1,6 @@
 global_defs {
 	# Keepalived process identifier
-	lvs_id <%= spec.name %> 
+	lvs_id <%= spec.name %>
 }
 # Healthcheck test to be performed, if rc is different than 0, new master election is required between all the remaining nodes
 vrrp_script <%= p('keepalived.healthcheck_name') %> {
@@ -18,6 +18,9 @@ vrrp_instance <%= spec.name+'_'+p('keepalived.healthcheck_name') %> {
 	state SLAVE
 	priority 100
 	<% end %>
+        <% if p('keepalived.dont_track_primary') %>
+        dont_track_primary
+        <% end %>
 	interface <%= p('keepalived.interface') %>
 	virtual_router_id <%= p('keepalived.virtual_router_id') %>
 # The virtual ip address shared between the two loadbalancers


### PR DESCRIPTION
We run into an issue where the vrrp vip is lost when DHCP lease is renwed due to OpenStack maintenance. This issue is described in more details [here](https://serverfault.com/questions/601670/keepalived-vip-removed-with-dhcp-renewal). 

This PR exposes the `dont_track_primary` which ignores VRRP interface faults.