### PR TITLE
Add drain script to enable graceful shutdown

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -9,6 +9,7 @@ packages:
 
 templates:
   haproxy_wrapper:            bin/haproxy_wrapper
+  drain.erb:                  bin/drain
   bpm.yml:                    config/bpm.yml
   haproxy.config.erb:         config/haproxy.config
   certs.ttar.erb:             config/certs.ttar
@@ -427,3 +428,9 @@ properties:
   ha_proxy.max_connections:
     description: Number of simultanous connections HAProxy supports handling
     default: 64000
+  ha_proxy.drain_enable:
+    description: Send SIGUSR1 signal to all haproxy processes in a drain script in order to gracefully shutdown
+    default: false
+  ha_proxy.drain_timeout:
+    description: Time in seconds after SIGUSR1 signal is sent in the drain script until monit stops the processes
+    default: 30

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -434,3 +434,6 @@ properties:
   ha_proxy.drain_timeout:
     description: Time in seconds after SIGUSR1 signal is sent in the drain script until monit stops the processes
     default: 30
+  ha_proxy.drain_frontend_grace_time:
+    description: Time in seconds after SIGUSR1 signal is sent in the drain script until the frontends stop accepting connections
+    default: 0

--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e -x
+
+pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
+logfile=/var/vcap/sys/log/haproxy/drain.log
+
+<% if not p("ha_proxy.drain_enable") -%>
+echo "drain is disabled" >> ${logfile}
+echo 0
+exit 0
+<% else -%>
+mkdir -p "$(dirname ${logfile})"
+
+if [[ ! -f ${pidfile} ]]; then
+  echo "$(date): pidfile does not exist" >> ${logfile}
+  echo 0
+  exit 0
+fi
+
+pid="$(cat ${pidfile})"
+
+haproxy_pids=$(pgrep -P $pid -l | grep haproxy | awk '{print $1}')
+
+for haproxy_pid in $haproxy_pids; do
+  kill -USR1 "${haproxy_pid}"
+  echo "$(date): triggering drain for process ${haproxy_pid}" >> ${logfile}
+done
+
+echo <%= p("ha_proxy.drain_timeout") -%>
+<% end -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -201,6 +201,9 @@ resolvers default
 # HTTP Frontend {{{
 frontend http-in
     mode http
+  <% if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
+  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -266,6 +269,9 @@ frontend http-in
 # HTTPS Frontend {{{
 frontend https-in
     mode http
+  <% if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
+  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -335,6 +341,9 @@ frontend https-in
 # HTTPS Websockets Frontend {{{
 frontend wss-in
     mode http
+  <% if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
+  <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -497,6 +506,9 @@ frontend cf_tcp_routing
     mode tcp
     bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
     default_backend cf_tcp_routers
+  <% if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
+  <%- end -%>
 
 backend cf_tcp_routers
     mode tcp
@@ -530,6 +542,9 @@ frontend tcp-frontend_<%= tcp_proxy["name"]%>
     bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>
   <%- end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
+  <% if p("ha_proxy.drain_enable") -%>
+    grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
+  <%- end -%>
 
 backend tcp-<%= tcp_proxy["name"] %>
     mode tcp


### PR DESCRIPTION
Currently, monit stop kills the haproxy processes and all established
connections are closed. A drain script is added to enable graceful
shutdown by sending a SIGUSR1 signal [1]. The script instructs bosh
to wait for a configurable period of time before it calls monit stop.

Draining is disabled by default

Additionally an option is added to allow frontends to accept new connections after SIGUSR1.
This is useful to give load balancers time to detect the failing health check.

[1] https://cbonte.github.io/haproxy-dconv/1.7/management.html#4