### PR TITLE
Read trusted_domain_cidrs from a file

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -20,6 +20,7 @@ templates:
   client-revocation-list.erb: config/client-revocation-list.pem
   blacklist_cidrs.txt.erb:    config/blacklist_cidrs.txt
   whitelist_cidrs.txt.erb:    config/whitelist_cidrs.txt
+  trusted_domain_cidrs.txt.erb: config/trusted_domain_cidrs.txt
 
 consumes:
   - name: http_backend

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -242,7 +242,7 @@ frontend http-in
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
-    acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
+    acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt
     <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
     <%- end -%>
@@ -321,7 +321,7 @@ frontend https-in
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
-    acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
+    acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt
     <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
     <%- end -%>
@@ -393,7 +393,7 @@ frontend wss-in
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
-    acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
+    acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt
     <%- p("ha_proxy.internal_only_domains").each do |domain| -%>
     acl internal hdr(Host) -m sub <%= domain %>
     <%- end -%>

--- a/jobs/haproxy/templates/trusted_domain_cidrs.txt.erb
+++ b/jobs/haproxy/templates/trusted_domain_cidrs.txt.erb
@@ -1,0 +1,28 @@
+# generated from trusted_domain_cidrs.txt.erb
+<%
+require "base64"
+require 'zlib'
+require 'stringio'
+
+def contains_ip_address?(str)
+  !!(str =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+end
+
+if_p("ha_proxy.trusted_domain_cidrs") do |cidrs|
+  uncompressed = ''
+  if contains_ip_address?(cidrs) then
+    cidrs.split(' ').each do |cidr|
+      uncompressed << cidr << "\n"
+    end
+  else
+    gzplain = Base64.decode64(cidrs)
+    gz = Zlib::GzipReader.new(StringIO.new(gzplain))
+    uncompressed = gz.read
+  end
+%>
+# BEGIN trusted_domain cidrs
+<%= uncompressed %>
+# END trusted_domain cidrs
+<%
+end
+%>


### PR DESCRIPTION
When the trusted_domain_cidrs list was too long haproxy start-up failed
with the following error:
parsing [/var/vcap/jobs/haproxy/config/haproxy.config:60]: line too long,
truncating at word 65, position 1049

Additionally trusted_domain_cidrs can be provided as a base64 encoded
string.