### PR TITLE
Fix haproxy_wrapper cleanup_daemon

### DIFF
--- a/jobs/haproxy/templates/haproxy_wrapper
+++ b/jobs/haproxy/templates/haproxy_wrapper
@@ -10,8 +10,8 @@ PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
 export PATH=$PATH:/var/vcap/packages/ttar/bin
 
 cleanup_daemon() {
-  if -f ${PID_FILE}; then
-    pkill -F ${PID_FILE}
+  if [ -f ${PID_FILE} ]; then
+    pkill -F ${PID_FILE} || true
   fi
   rm -f /var/vcap/sys/run/haproxy/*
 }


### PR DESCRIPTION
Fixes issue #140
Fixes this error
```
/var/vcap/jobs/haproxy/bin/haproxy_wrapper: line 13: -f: command not found
```

Also added `|| true` to prevent script from exiting if the process could no longer be found.