### PR TITLE
Make HAProxy stat authentication optional

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -210,9 +210,9 @@ properties:
     description: "Define listening address and port for the stats frontend. If multithreading is enabled (`ha_proxy.threads > 1`) multiple stat pages are available - one for each thread. You can see the stat page for each thread on a separate port - starting at the defined port number."
     default: "*:9000"
   ha_proxy.stats_user:
-    description: "User name to authenticate haproxy stats"
+    description: "Optional user name to authenticate haproxy stats"
   ha_proxy.stats_password:
-    description: "Password to authenticate haproxy stats"
+    description: "Optional password to authenticate haproxy stats"
   ha_proxy.stats_uri:
     description: "URI used to access the stats UI."
     default: "haproxy_stats"
@@ -379,7 +379,7 @@ properties:
   ha_proxy.http_request_deny_conditions:
       description: |
         List of conditions to block http requests. Each condition consists of multiple rules combined with the AND operator. Setting
-        the negate flag to true will negate the acl condition. 
+        the negate flag to true will negate the acl condition.
 
       example:
         http_request_deny_conditions:
@@ -391,13 +391,13 @@ properties:
           - acl_name: whitelist_ips
             acl_rule: "src 5.22.5.11 5.22.5.12"
             negate: true
-         
+
 
   ha_proxy.cidrs_in_file:
     description: |
-      List of cidrs that will be placed in /var/vcap/jobs/haproxy/config/cidrs/<name>. Useful for acl's that reference 
+      List of cidrs that will be placed in /var/vcap/jobs/haproxy/config/cidrs/<name>. Useful for acl's that reference
       a long list of cidrs (invoke the file with -f /var/vcap/jobs/haproxy/config/cidrs/<name>).
-    
+
     example:
       cidrs_in_file:
       - name: sample_cidrs

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -176,7 +176,9 @@ listen stats_<%= proc %>
     stats hide-version
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
-    stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
+    <% if properties.ha_proxy.stats_user and properties.ha_proxy.stats_password -%>
+     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
+       <%- end -%>
   <%- end -%>
 <% end -%>
 


### PR DESCRIPTION
HAProxy stats can be enabled without authentication. 
With this PR the HAProxy-boshrelease could have the same functionality by making the user and password optional.
Additionally, authentication doesn't make sense when the service is bind to localhost and when the trusted_stats_cidrs is limited to 127.0.0.1