### PR TITLE
Remove leftover `-x` bash opt

### DIFF
--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 # vim: set ft=sh
 
-set -e -x
+set -e
 
 pidfile=/var/vcap/sys/run/bpm/haproxy/haproxy.pid
 logfile=/var/vcap/sys/log/haproxy/drain.log


### PR DESCRIPTION
Too verbose, probably leftover from debugging.