### PR TITLE
Fix drain script for bpm v1.1.0

### DIFF
--- a/jobs/haproxy/templates/drain.erb
+++ b/jobs/haproxy/templates/drain.erb
@@ -21,7 +21,7 @@ fi
 
 pid="$(cat ${pidfile})"
 
-haproxy_pids=$(pgrep -P $pid -l | grep haproxy | awk '{print $1}')
+haproxy_pids=$(pgrep -P $pid -l | grep 'haproxy$' | awk '{print $1}')
 
 for haproxy_pid in $haproxy_pids; do
   kill -USR1 "${haproxy_pid}"


### PR DESCRIPTION
With bpm 1.1.0 `haproxy_wrapper` is not started directly, but indirectly through [`tini`](https://github.com/cloudfoundry/bpm-release/commit/49d8ede5fc240cc3f135071aaadf19081e038182).
This breaks the functionality of the drain script, since `grep haproxy` also matches `haproxy_wrapper` which leads to a non graceful shutdown.

bpm 1.0.0:
```
haproxy/c2cdb159-9289-45ed-a223-a7d6ec608b8c:~$ ps aux | grep haproxy
vcap      4724  0.0  0.0  19708  3380 ?        S<s  12:01   0:00 /bin/bash /var/vcap/jobs/haproxy/bin/haproxy_wrapper
vcap      4753  0.1  0.3  49440 15052 ?        S<s  12:01   0:00 /var/vcap/packages/haproxy/bin/haproxy -f /var/vcap/jobs/haproxy/config/haproxy.config -D -p /var/vcap/sys/run/haproxy/haproxy.pid
bosh_9d+  4873  0.0  0.0  12944  1008 pts/0    S+   12:04   0:00 grep --color=auto haproxy
```

bpm 1.1.0:
```
haproxy/c2cdb159-9289-45ed-a223-a7d6ec608b8c:/var/vcap/jobs/haproxy/bin# ps aux | grep haproxy
vcap      1004  0.2  0.0   4364   648 ?        S<s  11:38   0:00 /var/vcap/packages/bpm/bin/tini -w -s -- /var/vcap/jobs/haproxy/bin/haproxy_wrapper
vcap      1021  0.0  0.0  19708  3368 ?        S<   11:38   0:00 /bin/bash /var/vcap/jobs/haproxy/bin/haproxy_wrapper
vcap      1035  0.0  0.3  49304 15072 ?        S<s  11:38   0:00 /var/vcap/packages/haproxy/bin/haproxy -f /var/vcap/jobs/haproxy/config/haproxy.config -D -p /var/vcap/sys/run/haproxy/haproxy.pid
root      1042  0.0  0.0  12944  1080 pts/0    S+   11:38   0:00 grep --color=auto haproxy
```

Fix: Make sure to only match process names that end with `haproxy`.