### PR TITLE
add feature to avoid cross-az traffic

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -472,3 +472,7 @@ properties:
   ha_proxy.drain_frontend_grace_time:
     description: Time in seconds after SIGUSR1 signal is sent in the drain script until the frontends stop accepting connections
     default: 0
+  ha_proxy.backend_prefer_local_az:
+    description: |
+      Prefer backend servers which are located on the same availability zone
+    default: true

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -475,4 +475,4 @@ properties:
   ha_proxy.backend_prefer_local_az:
     description: |
       Prefer backend servers which are located on the same availability zone
-    default: true
+    default: false

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -476,8 +476,7 @@ backend http-routers
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
   <%- end -%>
   <%- backend_servers.each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
-
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%> 
   <%- end -%>
 # }}}
 
@@ -601,8 +600,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   end
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
-
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%> 
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -600,7 +600,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   end
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -477,6 +477,7 @@ backend http-routers
   <%- end -%>
   <%- backend_servers.each_with_index do |ip, index| -%>
     server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
+
   <%- end -%>
 # }}}
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -551,7 +551,7 @@ if_link("tcp_backend") do |tcp_backend|
   tcp << {
     "name" => tcp_backend.instances.first.name || "link",
     "backend_servers" => tcp_backend.instances.map(&:address),
-    "backend_servers_local" => tcp_backend.address(azs: [spec.az])
+    "backend_servers_local" => tcp_backend.address(azs: [spec.az]),
     "port" => tcp_backend.p("port", p("ha_proxy.tcp_link_port")),
     "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port")),
     "health_check_http" => tcp_backend.p("health_check_http", p("ha_proxy.tcp_link_health_check_http", nil))

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -154,6 +154,9 @@ defaults
     option httplog
     option forwardfor
     option contstats
+  <%- if p("ha_proxy.backend_prefer_local_az") -%>
+    option allbackups
+  <%- end -%>
     timeout connect         <%= (p("ha_proxy.connect_timeout").to_f    * 1000).to_i %>ms
     timeout client          <%= (p("ha_proxy.client_timeout").to_f     * 1000).to_i %>ms
     timeout server          <%= (p("ha_proxy.server_timeout").to_f     * 1000).to_i %>ms
@@ -437,10 +440,15 @@ backend http-routers
     <%- end -%>
     <%
   backend_servers = []
+  backend_servers_local = []
   backend_port = nil
   if_link("http_backend") do |backend|
     backend_servers = backend.instances.map(&:address)
     backend_port = backend.p("port", p("ha_proxy.backend_port"))
+
+    if p("ha_proxy.backend_prefer_local_az") then
+      backend_servers_local = backend.address(azs: [spec.az])
+    end
   end.else_if_p("ha_proxy.backend_servers") do |servers|
     backend_servers = servers
     backend_port = p("ha_proxy.backend_port")
@@ -468,7 +476,7 @@ backend http-routers
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
   <%- end -%>
   <%- backend_servers.each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %>
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
   <%- end -%>
 # }}}
 
@@ -543,6 +551,7 @@ if_link("tcp_backend") do |tcp_backend|
   tcp << {
     "name" => tcp_backend.instances.first.name || "link",
     "backend_servers" => tcp_backend.instances.map(&:address),
+    "backend_servers_local" => tcp_backend.address(azs: [spec.az])
     "port" => tcp_backend.p("port", p("ha_proxy.tcp_link_port")),
     "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port")),
     "health_check_http" => tcp_backend.p("health_check_http", p("ha_proxy.tcp_link_health_check_http", nil))
@@ -591,7 +600,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   end
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %>
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -447,7 +447,7 @@ backend http-routers
     backend_port = backend.p("port", p("ha_proxy.backend_port"))
 
     if p("ha_proxy.backend_prefer_local_az") then
-      backend_servers_local = backend.address(azs: [spec.az])
+      backend_servers_local = backend.instances.select{ |n| n.az == spec.az }.map(&:address)
     end
   end.else_if_p("ha_proxy.backend_servers") do |servers|
     backend_servers = servers
@@ -552,7 +552,7 @@ if_link("tcp_backend") do |tcp_backend|
   tcp << {
     "name" => tcp_backend.instances.first.name || "link",
     "backend_servers" => tcp_backend.instances.map(&:address),
-    "backend_servers_local" => tcp_backend.address(azs: [spec.az]),
+    "backend_servers_local" => tcp_backend.instances.select{ |n| n.az == spec.az }.map(&:address),
     "port" => tcp_backend.p("port", p("ha_proxy.tcp_link_port")),
     "backend_port" => tcp_backend.p("backend_port", p("ha_proxy.tcp_link_port")),
     "health_check_http" => tcp_backend.p("health_check_http", p("ha_proxy.tcp_link_health_check_http", nil))

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -601,6 +601,7 @@ backend tcp-<%= tcp_proxy["name"] %>
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
     server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
+
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/spec/haproxy_templates_spec.rb
+++ b/spec/haproxy_templates_spec.rb
@@ -79,7 +79,8 @@ describe 'haproxy' do
         'max_connections' => '64000',
         'drain_enable' => false,
         'drain_timeout' => 30,
-        'drain_frontend_grace_time' => 0
+        'drain_frontend_grace_time' => 0,
+        'backend_prefer_local_az' => true
       }
     }
   end

--- a/spec/haproxy_templates_spec.rb
+++ b/spec/haproxy_templates_spec.rb
@@ -80,7 +80,7 @@ describe 'haproxy' do
         'drain_enable' => false,
         'drain_timeout' => 30,
         'drain_frontend_grace_time' => 0,
-        'backend_prefer_local_az' => true
+        'backend_prefer_local_az' => false
       }
     }
   end


### PR DESCRIPTION
Cross-AZ traffic will cause extra costs on iaas providers like AWS, therefore prefer traffic to local AZs.
This will be implemented via backup server, which will get called only if the remaining regular servers are down