### PR TITLE
Enable simultaneous binding to IPv4+IPv6 interfaces

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -351,8 +351,11 @@ properties:
     description: "Disables the PROXY protocol on tcp backends. Only applies if `ha_proxy.accept_proxy` is enabled."
     default: false
   ha_proxy.binding_ip:
-    description: "If there are multiple ethernet interfaces, specify which one to bind"
+    description: "If there are multiple ethernet interfaces, specify which one to bind. Set to `::` to bind to all IPv6 interfaces (no IPv4). IPv6 must be enabled on the HAProxy VM in the deployment manifest."
     default: ""
+  ha_proxy.v4v6:
+    description: "Boolean, disabled by default. Enables binding to all IPv4 and IPv6 interfaces. Only applies if `ha_proxy.binding_ip` is set to `::`."
+    default: false
 
   ha_proxy.cidr_blacklist:
     description: "List of CIDRs to block for http(s). Format is string array of CIDRs or single string of base64 encoded gzip."

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -99,6 +99,14 @@ else
   abort("Unkown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set'")
 end
 # }}}
+# IPv4 and IPv6 binding (v4v6) Option {{{
+v4v6 = ""
+if_p("ha_proxy.v4v6") do
+  if p("ha_proxy.binding_ip") == "::" then
+    v4v6 = "v4v6"
+  end
+end
+# }}}
 -%>
 
 global
@@ -207,7 +215,7 @@ frontend http-in
   <% if p("ha_proxy.drain_enable") -%>
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
-    bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %>
+    bind <%= p("ha_proxy.binding_ip") %>:80 <%= accept_proxy %> <%= v4v6 %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
@@ -279,7 +287,7 @@ frontend https-in
   <% if p("ha_proxy.drain_enable") -%>
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
-    bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %>
+    bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
@@ -355,7 +363,7 @@ frontend wss-in
   <% if p("ha_proxy.drain_enable") -%>
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
-    bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %>
+    bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>
@@ -527,7 +535,7 @@ backend http-routed-backend-<%= prefix_hash %>
 
 frontend cf_tcp_routing
     mode tcp
-    bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= p("ha_proxy.tcp_routing.port_range") %> <%= v4v6 %>
     default_backend cf_tcp_routers
   <% if p("ha_proxy.drain_enable") -%>
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
@@ -561,9 +569,9 @@ end -%>
 frontend tcp-frontend_<%= tcp_proxy["name"]%>
     mode tcp
   <%- if tcp_proxy["ssl"] -%>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tcp_accept_proxy %> <%= tls_bind_options %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= tcp_accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
   <%- else -%>
-    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %>
+    bind <%= p("ha_proxy.binding_ip") %>:<%= tcp_proxy["port"] %> <%= v4v6 %>
   <%- end -%>
     default_backend tcp-<%= tcp_proxy["name"] %>
   <% if p("ha_proxy.drain_enable") -%>

--- a/spec/haproxy_templates_spec.rb
+++ b/spec/haproxy_templates_spec.rb
@@ -65,6 +65,7 @@ describe 'haproxy' do
         'accept_proxy' => false,
         'disable_tcp_accept_proxy' => false,
         'binding_ip' => '',
+        'v4v6' => false,
         'cidr_blacklist' => '~',
         'cidr_whitelist' => '~',
         'block_all' => false,


### PR DESCRIPTION
We introduce a new manifest property to the `haproxy` job, `ha_proxy.v4v6`, which propagates the HAProxy configuration directive, [`v4v6`](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1-v4v6), which, when the `binding_ip` is set to `::` (bind to every IPv6 interface, i.e. [`in6addr_any`](http://man7.org/linux/man-pages/man7/ipv6.7.html)), will also bind to every IPv4 interface (i.e. 0.0.0.0, `INADDR_ANY`).

This should have **no affect** on existing manifests. This should have no effect on existing behavior (unless the property is enabled): The new property, `v4v6`, is disabled by default. Furthermore, it will _only_ be instantiated if the `haproxy.binding_ip` is set to `::`.

Includes test for new property.

This feature would be useful in dual-stack environments (both IPv4 & IPv6) with a dearth of IPv4 addresses but an abundance of IPv6 addresses (e.g. a Comcast subscriber with 1 IPv4 address and 8 x /64 IPv6 subnets)

Sample manifest snippet:

```yaml
instance_groups:
- name: haproxy
  jobs:
  - name: haproxy
    properties:
      ha_proxy:
        binding_ip: "::"
        v4v6: true
```

Thanks for all the great work! I love HAProxy.

To see a live sample of an HAProxy running with these changes (assuming your workstation has IPv6):

```shell
curl -6 https://dora.cf.nono.io/env.json | jq -r .
```

It binds to the IPv4 address, too. I can connect to it when I'm on the internal network (its IPv4 address is internal-only):

```shell
printf "IPv4: "; curl -4 https://dora.cf.nono.io; printf "\nIPv6: "; curl -6 https://dora.cf.nono.io
IPv4: Hi, I'm Dora!
IPv6: Hi, I'm Dora!
```