### PR TITLE
make bpm log path configurable

### DIFF
--- a/jobs/haproxy/templates/bpm.yml
+++ b/jobs/haproxy/templates/bpm.yml
@@ -8,9 +8,11 @@ processes:
         writable: true
       - path: /var/vcap/sys/run/haproxy
         writable: true
+<%- if p("ha_proxy.syslog_server") && p("ha_proxy.syslog_server").chars.first == "/" -%>
     unsafe:
       unrestricted_volumes:
-        - path: /dev/log
+        - path: <%= p("ha_proxy.syslog_server") %>
+<%- end -%>
     limits:
       open_files: <%= p("ha_proxy.max_open_files") %>
     capabilities:


### PR DESCRIPTION
since the bpm adoption, the property ha_proxy.syslog_server does not make sense in case a local unix socket from the root filesystem should get integrated. Therefore this property needs to be configurable to make the path visible inside the container