### PR TITLE
Revert "Make HAProxy stat authentication optional"

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -216,9 +216,9 @@ properties:
     description: "Define listening address and port for the stats frontend. If multithreading is enabled (`ha_proxy.threads > 1`) multiple stat pages are available - one for each thread. You can see the stat page for each thread on a separate port - starting at the defined port number."
     default: "*:9000"
   ha_proxy.stats_user:
-    description: "Optional user name to authenticate haproxy stats"
+    description: "User name to authenticate haproxy stats"
   ha_proxy.stats_password:
-    description: "Optional password to authenticate haproxy stats"
+    description: "Password to authenticate haproxy stats"
   ha_proxy.stats_uri:
     description: "URI used to access the stats UI."
     default: "haproxy_stats"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -187,9 +187,7 @@ listen stats_<%= proc %>
     stats hide-version
     stats realm "Haproxy Statistics"
     stats uri /<%= p("ha_proxy.stats_uri") %>
-    <% if properties.ha_proxy.stats_user and properties.ha_proxy.stats_password -%>
-     stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-       <%- end -%>
+    stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
   <%- end -%>
 <% end -%>
 


### PR DESCRIPTION
Reverts cloudfoundry-incubator/haproxy-boshrelease#144