### PR TITLE
Add support for hitless reloads

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -9,6 +9,7 @@ packages:
 
 templates:
   haproxy_wrapper:              bin/haproxy_wrapper
+  reload:                       bin/reload
   drain.erb:                    bin/drain
   pre-start.erb:                bin/pre-start
   bpm.yml:                      config/bpm.yml

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -142,10 +142,10 @@ global
     tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
   <%- if nbproc > 1 -%>
     <%- 1.upto(nbproc) do |proc| -%>
-    stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 level admin process <%= proc%>
+    stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 expose-fd listeners level admin process <%= proc%>
     <%- end -%>
   <%- else -%>
-    stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
+    stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 expose-fd listeners level admin
   <%- end -%>
     stats timeout 2m
     ssl-default-bind-options <%= ssl_flags %>
@@ -484,7 +484,7 @@ backend http-routers
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
   <%- end -%>
   <%- backend_servers.each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%> 
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
   <%- end -%>
 # }}}
 
@@ -608,7 +608,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   end
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%> 
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -484,7 +484,7 @@ backend http-routers
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
   <%- end -%>
   <%- backend_servers.each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%> 
   <%- end -%>
 # }}}
 
@@ -608,7 +608,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   end
 -%>
   <%- tcp_proxy["backend_servers"].each_with_index do |ip, index| -%>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%> 
   <%- end -%>
 
   <%- if tcp_proxy["health_check_http"] then -%>

--- a/jobs/haproxy/templates/haproxy_wrapper
+++ b/jobs/haproxy/templates/haproxy_wrapper
@@ -7,6 +7,7 @@ PATH=/var/vcap/packages/haproxy/bin:${PATH}
 DAEMON=/var/vcap/packages/haproxy/bin/haproxy
 CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
+SOCK_FILE=/var/vcap/sys/run/haproxy/stats.sock
 export PATH=$PATH:/var/vcap/packages/ttar/bin
 
 cleanup_daemon() {
@@ -14,6 +15,12 @@ cleanup_daemon() {
     pkill -F ${PID_FILE} || true
   fi
   rm -f /var/vcap/sys/run/haproxy/*
+}
+
+reload_daemon() {
+    echo "$(date): Reloading HAProxy"
+    "${DAEMON}" -f "${CONFIG}" -D -p ${PID_FILE} -sf "$(cat ${PID_FILE})" -x ${SOCK_FILE} 0<&-
+    sleep infinity
 }
 
 # reconstitute certs based on ttar file
@@ -29,6 +36,9 @@ cleanup_daemon
 
 # ensure we shut down the daemonized process correctly on exit
 trap shutdown QUIT INT TERM EXIT
+
+# enable hitless reloads
+trap reload_daemon USR2
 
 # Start up
 echo "$(date): Starting HAProxy"

--- a/jobs/haproxy/templates/reload
+++ b/jobs/haproxy/templates/reload
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+bpm=/var/vcap/packages/bpm/bin/bpm
+
+if $bpm pid haproxy > /dev/null; then
+  haproxy_pid=$($bpm pid haproxy)
+  echo "Reloading HAProxy (pid: ${haproxy_pid})"
+  kill -USR2 -"${haproxy_pid}"
+else
+  echo "Could not find HAproxy pid. Exiting."
+  exit 1
+fi


### PR DESCRIPTION
This will enable seamless reloads of HAproxy without draining and re-deploying via BOSH.
For background info see https://www.haproxy.com/blog/hitless-reloads-with-haproxy-howto/

Background:
We would like to reload HAproxy without stopping it and losing all connections. HAproxy should only be restarted if there is a new version or a stemcell update.
Since there is no such thing as "reload" in either the BOSH lifecycle or BPM lifecycle, we will keep this as a special case and don't want to disrupt the existing deployment mechanism.

Adding this will allow us to seamlessly reload HAproxy without dropping a single connection (as long a there are no changes in the BOSH manifest of course).

I've added a signal handler to the haproxy_wrapper that reloads haproxy as described in https://www.haproxy.com/blog/hitless-reloads-with-haproxy-howto/ 

The signal can be fired conveniently by calling the added `reload` script.

The normal monit/bpm lifecycle is not affected and works just as before.