### PR TITLE
HAProxy 2.1, native prometheus metrics, TLS v1.3 (OpenSSL 1.1.1d)

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,10 @@ haproxy/haproxy-1.9.11.tar.gz:
   size: 2389403
   object_id: 4bda3907-6582-4557-7306-9593e7d08725
   sha: 664ee6fc3d88f76dfa59b23ebf1481cc642cf1b8
+haproxy/haproxy-2.1.3.tar.gz:
+  size: 2675529
+  object_id: 69b386d6-6534-466d-77e2-9e6d661dd0a6
+  sha: sha256:bb678e550374d0d9d9312885fb9d270b501dae9e3b336f0a4379c667dae00b59
 haproxy/hatop:
   size: 72429
   object_id: d86cd983-5ca3-4293-6620-56a9273be80f
@@ -10,6 +14,10 @@ haproxy/lua-5.3.5.tar.gz:
   size: 303543
   object_id: 5acd4a28-51a4-45ed-536b-766fec394fa5
   sha: 112eb10ff04d1b4c9898e121d6bdf54a81482447
+haproxy/openssl-1.1.1d.tar.gz:
+  size: 8845861
+  object_id: 78ef4d62-cb64-4e97-7f67-eb6e5f4ef9ac
+  sha: sha256:1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
 haproxy/pcre2-10.33.tar.gz:
   size: 2234905
   object_id: 06b7a60f-7073-48db-7880-33a9c1eb60e4

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -160,8 +160,8 @@ properties:
     description: "If this is set to 'true', a https redirect rule for all http calls will be put in the config file"
     default: false
   ha_proxy.ssl_ciphers:
-    default: ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
-    description: "List of SSL Ciphers that are passed to HAProxy"
+    default: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA25:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    description: "List of SSL Ciphers that are passed to HAProxy. Security/Server Side TLS Recommended configurations: https://wiki.mozilla.org/Security/Server_Side_TLS"
   ha_proxy.hsts_enable:
     default: false
     description: "Enables HSTS(Strict-Transport-Security Header) for all the SSL/TLS listeners"
@@ -181,10 +181,10 @@ properties:
     default: true
     description: "Improve (Perfect) Forward Secrecy by disabling TLS tickets"
   ha_proxy.disable_tls_10:
-    default: false
+    default: true
     description: "Disable TLS 1.0 in HA Proxy"
   ha_proxy.disable_tls_11:
-    default: false
+    default: true
     description: "Disable TLS 1.1 in HA Proxy"
 
   ha_proxy.connect_timeout:
@@ -225,6 +225,22 @@ properties:
   ha_proxy.trusted_stats_cidrs:
     description: "Trusted ip range that can access the stats UI"
     default: 0.0.0.0/32
+
+  ha_proxy.prometheus_exporter.enable:
+    description: "If true, haproxy will enable native prometheus exporter. You can see the metrics on `haproxy_ip:9101/metrics`."
+    default: false
+  ha_proxy.prometheus_exporter.bind:
+    description: "Define listening address and port for the prometheus exporter frontend. https://github.com/prometheus/prometheus/wiki/Default-port-allocations "
+    default: "*:9101"
+  ha_proxy.prometheus_exporter.path:
+    description: "Define prometheus exporter path."
+    default: "/metrics"
+  ha_proxy.prometheus_exporter.stats.enable:
+    description: "If true, haproxy will serve stats too. If you need more options please use `ha_proxy.stats_enable`"
+    default: false
+  ha_proxy.prometheus_exporter.stats.path:
+    description: "Define haproxy stats path."
+    default: "/stats"
 
   ha_proxy.backend_servers:
     description: "Array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -191,6 +191,7 @@ listen stats_<%= proc %>
   <%- end -%>
 <% end -%>
 
+
 <% if p("ha_proxy.enable_health_check_http") %>
 listen health_check_http_url
     bind :<%= p("ha_proxy.health_check_port") %>
@@ -207,6 +208,20 @@ resolvers default
     nameserver <%= resolver.keys[0] %> <%= resolver.values[0] %>:53
   <%- end -%>
 <% end -%>
+
+
+<% if p("ha_proxy.prometheus_exporter.enable") %>
+frontend prometheus_exporter
+    mode http
+    bind <%= p("ha_proxy.prometheus_exporter.bind") %>
+    option http-use-htx
+    http-request use-service prometheus-exporter if { path <%= p("ha_proxy.prometheus_exporter.path") %> }
+    <% if p("ha_proxy.prometheus_exporter.stats.enable") %>
+    stats enable
+    stats uri <%= p("ha_proxy.prometheus_exporter.stats.path") %>
+    stats refresh 10s
+    <% end %>
+<% end %>
 
 <% unless p("ha_proxy.disable_http") -%>
 # HTTP Frontend {{{
@@ -248,12 +263,12 @@ frontend http-in
   <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -269,7 +284,7 @@ frontend http-in
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
-    reqadd X-Forwarded-Proto:\ http if ! xfp_exists
+    http-request add-header X-Forwarded-Proto http if ! xfp_exists
   <%- if p("ha_proxy.https_redirect_all") -%>
     redirect scheme https code 301 if !{ ssl_fc }
   <%- end -%>
@@ -331,12 +346,12 @@ frontend https-in
   <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -352,7 +367,7 @@ frontend https-in
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
-    reqadd X-Forwarded-Proto:\ https if ! xfp_exists
+    http-request add-header X-Forwarded-Proto https if ! xfp_exists
 # }}}
 <% end -%>
 
@@ -407,12 +422,12 @@ frontend wss-in
   <%- end -%>
   <%- if_p("ha_proxy.headers") do |headers| -%>
     <%- headers.each do |header, value| -%>
-    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
+    http-request add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> <%= value.to_s.gsub(/(?!:\\) /, '\ ') %>
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -428,7 +443,7 @@ frontend wss-in
     use_backend http-routed-backend-<%= prefix_hash %> if routed_backend_<%= prefix_hash %>
   <%- end -%>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
-    reqadd X-Forwarded-Proto:\ https if ! xfp_exists
+    http-request add-header X-Forwarded-Proto https if ! xfp_exists
 # }}}
 <% end -%>
 

--- a/jobs/haproxy/templates/haproxy_wrapper
+++ b/jobs/haproxy/templates/haproxy_wrapper
@@ -9,6 +9,9 @@ CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
 export PATH=$PATH:/var/vcap/packages/ttar/bin
 
+# provided openssl
+export LD_LIBRARY_PATH=/var/vcap/packages/haproxy/lib/
+
 cleanup_daemon() {
   if [ -f ${PID_FILE} ]; then
     pkill -F ${PID_FILE} || true

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -4,7 +4,8 @@ set -e
 LUA_VERSION=5.3.5
 PCRE_VERSION=10.33
 SOCAT_VERSION=1.7.3.3
-HAPROXY_VERSION=1.9.11
+OPENSSL_VERSION=1.1.1d
+HAPROXY_VERSION=2.1.3
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 
@@ -31,9 +32,24 @@ pushd socat-${SOCAT_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/socat
 popd
 
+# https://github.com/openssl/openssl/blob/master/INSTALL
+# https://dnsprivacy.org/wiki/display/DP/Building+HAProxy+so+that+it+can+use+TLSv1.3
+tar xf haproxy/openssl-${OPENSSL_VERSION}.tar.gz
+pushd openssl-${OPENSSL_VERSION}
+  ./config --prefix=${BOSH_INSTALL_TARGET} shared
+  make
+  make install
+  chmod 755 ${BOSH_INSTALL_TARGET}/bin/openssl
+popd
+
 tar xf haproxy/haproxy-${HAPROXY_VERSION}.tar.gz
 pushd haproxy-${HAPROXY_VERSION}
-  make TARGET=linux2628 USE_OPENSSL=1 USE_PCRE2=1 USE_PCRE2_JIT=yes USE_STATIC_PCRE2=1 USE_ZLIB=1 PCRE2DIR=${BOSH_INSTALL_TARGET} USE_LUA=1 LUA_LIB=${BOSH_INSTALL_TARGET}/lib LUA_INC=${BOSH_INSTALL_TARGET}/include
+  make TARGET=linux-glibc \
+     USE_LUA=1 LUA_LIB=${BOSH_INSTALL_TARGET}/lib LUA_INC=${BOSH_INSTALL_TARGET}/include \
+     USE_PCRE2=1 USE_PCRE2_JIT=1 USE_STATIC_PCRE2=1 PCRE2DIR=${BOSH_INSTALL_TARGET} \
+     USE_OPENSSL=1 SSL_LIB=${BOSH_INSTALL_TARGET}/lib SSL_INC=${BOSH_INSTALL_TARGET}/include \
+     USE_ZLIB=1 \
+     EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"
   cp haproxy ${BOSH_INSTALL_TARGET}/bin/
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
 popd

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -2,6 +2,7 @@
 name: haproxy
 files:
 - haproxy/haproxy-*.tar.gz
+- haproxy/openssl-*.tar.gz
 - haproxy/pcre2-*.tar.gz
 - haproxy/socat-*.tar.gz
 - haproxy/lua-*.tar.gz


### PR DESCRIPTION
### Main changes
- HAProxy upgraded to [v2.1 "Supercharged Performance and a Streamlined Codebase"](https://www.haproxy.com/blog/haproxy-2-1/), [native Prometheus metrics](https://github.com/haproxy/haproxy/tree/master/contrib/prometheus-exporter) ([Grafana dashboard](https://grafana.com/grafana/dashboards/10225))
- OpenSSL upgraded to [v1.1.1d](https://www.openssl.org/news/openssl-1.1.1-notes.html),  [TLS v1.3](https://wiki.openssl.org/index.php/TLS1.3) supported

### Other changes:
#### - Replaced deprecated `reqadd` rule
`reqadd` to `http-request add-header`, because the `reqadd` has been deprecated since the [`v2.0`](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4-reqadd) and removed in [`2.1`](https://cbonte.github.io/haproxy-dconv/2.1/configuration.html#4-reqadd)

#### - Improved default security config
- [Security/Server Side TLS Recommended configurations](https://wiki.mozilla.org/Security/Server_Side_TLS):
  - `ha_proxy.ssl_ciphers: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA25:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384` 
- `ha_proxy.disable_tls_10: true`
- `ha_proxy.disable_tls_11: true`

Now this config passes [SSL Test](https://www.ssllabs.com/ssltest/) with the Overall Rating: `A` 
![ssl-labs](https://user-images.githubusercontent.com/2461648/75014279-36cd5a80-5486-11ea-9dfd-687304c4958f.png)


