### PR TITLE
Add configuration for tune.maxrewrite

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -63,6 +63,8 @@ properties:
   ha_proxy.buffer_size_bytes:
     description: "Buffer size to use for requests, any requests larger than this (large cookies or query strings) will result in a gateway error"
     default: 16384
+  ha_proxy.max_rewrite:
+    description: "Buffer size to use for header rewriting or appending. The default of haproxy is min(1024,buffer_size_bytes/2). Will be set to buffer_size_bytes/2 by haproxy if it is set to a larger value"
   ha_proxy.internal_only_domains:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -140,6 +140,9 @@ global
   <%- end -%>
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
     tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
+  <%- if_p("ha_proxy.max_rewrite") do -%>
+    tune.maxrewrite <%= p("ha_proxy.max_rewrite") %>
+  <%- end -%>
   <%- if nbproc > 1 -%>
     <%- 1.upto(nbproc) do |proc| -%>
     stats socket /var/vcap/sys/run/haproxy/stats<%= proc%>.sock mode 600 expose-fd listeners level admin process <%= proc%>


### PR DESCRIPTION
The tune.maxrewrite parameter [1] is used to configure space for header
rewriting or appending.

We observed that for large requests and high load the x-forwarded-client-cert
header was not added to the request when using sanitize_set. Increasing
tune.maxrewrite solved the issue.

[1] https://cbonte.github.io/haproxy-dconv/1.9/configuration.html#tune.maxrewrite