### PR TITLE
[manifests] Add sha + url bpm to make it downloadable for BOSH

### DIFF
--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -37,6 +37,8 @@ stemcells:
 releases:
 - name: bpm
   version: 1.1.8
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8
+  sha1: c956394fce7e74f741e4ae8c256b480904ad5942
 - name: haproxy
   version: 10.0.0
   url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v10.0.0/haproxy-10.0.0.tgz


### PR DESCRIPTION
Hi there,

I added the BPM URL + SHA to the manifest that makes it possible for the BOSH director to download the release by itself rather than making the operator to download and upload it manually.

Please find the URL + SHA information here: https://bosh.io/releases/github.com/cloudfoundry/bpm-release?all=1