### PR TITLE
Add support for additional external certificates

### DIFF
--- a/docs/external_certs.md
+++ b/docs/external_certs.md
@@ -1,0 +1,51 @@
+# Using HAProxy with additional External Certificates
+
+By default, the HAproxy BOSH manifest contains all certificates to be used during runtime.
+The way to pass the certificates can be either via the `ha_proxy.ssl_pem` property that sets one chain for
+the hostname HAproxy is running on. Or they can be passed via the `ha_proxy.crt_list` property, which is essentially
+a list of `ssl_pem` properties that allows to configure multiple entries for different hostnames using SNI.
+
+## What are External Certificates and why are they needed?
+
+If you are planning to use more than one certificate on your HAproxy you are most likely going to use the `ha_proxy.crt_list`
+property. The main use-case for this property is to register different trust configurations for different hosts.
+For example, if your HAproxy services both the secure.example.com and www.example.com hosts, they both might have different
+requirements towards security. One could be using mTLS and a more secure certificate than the other or they could be using different CAs.
+
+The problems start when you are using a very large `ha_proxy.crt_list` with dozens or even hundreds of entries while using BOSH to deploy them.
+The way BOSH works is that all certificates will become part of the manifest during rendering and those certificates will then be extracted
+from the manifest and onto the HAproxy disk during deployment. If the manifest becomes very large (> 20M) the time BOSH needs to render and deploy increases significantly. At the same time, providing your customers the capability to register custom domains and certificates tends to be a very dynamic process, i.e. you never know when a customer will register a domain and upload a certificate to deploy but you will want to deploy the new certificate as quickly as possible so the customer can use it right away. Using the given way, you'll end up deploying HAproxy all the time. The major downside of this is that every time you deploy HAproxy, there will be a brief moment where the old process exits and the new process has not yet started. This will drop all existing connections to HAproxy and any client connected at that moment will receive a disruption.
+
+How can this dilemma be solved? External certificates to the rescue!
+
+## How does it all work?
+
+The HAproxy BOSH release provides an additional property `ha_proxy.ext_crt_list` that enables the use of a second source of certificates.
+When used, HAproxy will expect an additional `crt-list` file to be present in a specific folder (by default: `/var/vcap/jobs/haproxy/config/ssl/ext`).
+If the file exists its contents will be merged with the existing certificates from the manifest before HAproxy is started.
+Since the list of certificates is now provided by two decoupled sources, those sources need to be synchronized in order to avoid starting HAproxy with an incomplete set of certificates. During startup, HAproxy will wait for the second `crt-list` file to appear. This allows an external service (e.g. another BOSH release) to generate the file and place it in the directory where it is expected.
+
+At runtime, when a new certificate needs to be added, the external service can simply update the second `crt-list` file and trigger a [hitless reload](https://www.haproxy.com/blog/hitless-reloads-with-haproxy-howto/) of HAproxy using the `/var/vcap/jobs/haproxy/bin/reload` command. No connections will be dropped.
+
+Depending on your configuration, HAproxy will refuse to start without external certificates or it will continue without them after a timeout.
+
+## Configuring HAproxy to use External Certificates
+
+The feature is controlled by these properties:
+```
+ha_proxy.ext_crt_list:
+    A flag denoting the use of additional certificates from external sources.
+    If set to true the contents of an external crt-list file located at `ha_proxy.ext_crt_list_file` are
+    added to the crt-list described by the `ha_proxy.crt_list` property.
+  default: false
+ha_proxy.ext_crt_list_file:
+    The location from which to load additional external certificates list
+  default: "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list"
+ha_proxy.ext_crt_list_timeout:
+    Timeout (in seconds) to wait for the external certificates list located at `ha_proxy.ext_crt_list_file` to appear during HAproxy startup
+  default: 60
+ha_proxy.ext_crt_list_policy:
+    What to do if the external certificates list located at `ha_proxy.ext_crt_list_file` does not appear within the time
+    denoted by `ha_proxy.ext_crt_list_timeout`. Set to either 'fail' (HAproxy will not start) or 'continue' (HAproxy will start without external certificates)
+  default: "fail"
+```

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -139,6 +139,11 @@ properties:
         - "*.domain.tld"
         - "!secure.domain.tld"
     default: ~
+  ha_proxy.ext_crt_list:
+    description: |
+      A flag denoting the use of additional certificates from external sources.
+      If set to true the contents of an external crt-list file located in /var/vcap/jobs/haproxy/config/ssl/ext/crt-list are added to the crt-list described by the "crt_list" property.
+    default: false
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
   ha_proxy.enable_health_check_http:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -8,7 +8,7 @@ packages:
 - ttar
 
 templates:
-  haproxy_wrapper:              bin/haproxy_wrapper
+  haproxy_wrapper.erb:          bin/haproxy_wrapper
   reload:                       bin/reload
   drain.erb:                    bin/drain
   pre-start.erb:                bin/pre-start
@@ -152,7 +152,7 @@ properties:
   ha_proxy.ext_crt_list_timeout:
     description: |
       Timeout (in seconds) to wait for the external certificates list located at `ha_proxy.ext_crt_list_file` to appear during HAproxy startup
-    default: 300
+    default: 60
   ha_proxy.ext_crt_list_policy:
     description: |
       What to do if the external certificates list located at `ha_proxy.ext_crt_list_file` does not appear within the time

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -142,8 +142,22 @@ properties:
   ha_proxy.ext_crt_list:
     description: |
       A flag denoting the use of additional certificates from external sources.
-      If set to true the contents of an external crt-list file located in /var/vcap/jobs/haproxy/config/ssl/ext/crt-list are added to the crt-list described by the "crt_list" property.
+      If set to true the contents of an external crt-list file located at `ha_proxy.ext_crt_list_file` are
+      added to the crt-list described by the `ha_proxy.crt_list` property.
     default: false
+  ha_proxy.ext_crt_list_file:
+    description: |
+      The location from which to load additional external certificates list
+    default: "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list"
+  ha_proxy.ext_crt_list_timeout:
+    description: |
+      Timeout (in seconds) to wait for the external certificates list located at `ha_proxy.ext_crt_list_file` to appear during HAproxy startup
+    default: 300
+  ha_proxy.ext_crt_list_policy:
+    description: |
+      What to do if the external certificates list located at `ha_proxy.ext_crt_list_file` does not appear within the time
+      denoted by `ha_proxy.ext_crt_list_timeout`. Set to either 'fail' (HAproxy will not start) or 'continue' (HAproxy will start without external certificates)
+    default: "fail"
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
   ha_proxy.enable_health_check_http:

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -69,13 +69,9 @@ if_p("ha_proxy.crt_list") do |crt_list|
       pem_block = pem_block['cert_chain'].strip + "\n" + pem_block['private_key'].strip
     end
 %>
-<%
-if_p("ha_proxy.ext_crt_list") do |ext_crt_list|
-  if ext_crt_list
-    %>#OPTIONAL_EXT_CERTS<%
-  end
-end
-%>
+<% if p("ha_proxy.ext_crt_list") == true %>
+  #OPTIONAL_EXT_CERTS
+<% end %>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
 <%= pem_block %>
 <%

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -69,6 +69,13 @@ if_p("ha_proxy.crt_list") do |crt_list|
       pem_block = pem_block['cert_chain'].strip + "\n" + pem_block['private_key'].strip
     end
 %>
+<%
+if_p("ha_proxy.ext_crt_list") do |ext_crt_list|
+  if ext_crt_list
+    %>#OPTIONAL_EXT_CERTS<%
+  end
+end
+%>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
 <%= pem_block %>
 <%

--- a/jobs/haproxy/templates/haproxy_wrapper
+++ b/jobs/haproxy/templates/haproxy_wrapper
@@ -18,14 +18,25 @@ cleanup_daemon() {
 }
 
 reload_daemon() {
+    update_certs
     echo "$(date): Reloading HAProxy"
     "${DAEMON}" -f "${CONFIG}" -D -p ${PID_FILE} -sf "$(cat ${PID_FILE})" -x ${SOCK_FILE} 0<&-
     sleep infinity
 }
 
-# reconstitute certs based on ttar file
-mkdir -p /var/vcap/jobs/haproxy/config/ssl
-ttar < /var/vcap/jobs/haproxy/config/certs.ttar
+update_certs() {
+  # reconstitute certs based on ttar file
+  mkdir -p /var/vcap/jobs/haproxy/config/ssl
+  ttar < /var/vcap/jobs/haproxy/config/certs.ttar
+
+  # merge optional external certs
+  if grep -q OPTIONAL_EXT_CERTS /var/vcap/jobs/haproxy/config/ssl/crt-list; then
+    sed -i -e '/OPTIONAL_EXT_CERTS/r /var/vcap/jobs/haproxy/config/ssl/ext/crt-list' /var/vcap/jobs/haproxy/config/ssl/crt-list
+  fi
+}
+
+# unpack base certs and add optional external certs
+update_certs
 
 # reconstitute cidrs based on ttar file
 mkdir -p /var/vcap/jobs/haproxy/config/cidrs

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -29,10 +29,43 @@ update_certs() {
   mkdir -p /var/vcap/jobs/haproxy/config/ssl
   ttar < /var/vcap/jobs/haproxy/config/certs.ttar
 
+  <%- if p("ha_proxy.ext_crt_list") == true -%>
+  # wait for optional external certs
+  local ext_crt_list_file=<%= p("ha_proxy.ext_crt_list_file") %>
+  local timeout=<%= p("ha_proxy.ext_crt_list_timeout") %>
+  local policy=<%= p("ha_proxy.ext_crt_list_policy") %>
+  <%- if not ["fail", "continue"].include?(p("ha_proxy.ext_crt_list_policy"))
+       abort("ha_proxy.ext_crt_list_policy must be either 'fail' or 'continue'")
+      end -%>
+  mkdir -p $(dirname $ext_crt_list_file)
+  chmod o+rwx $(dirname $ext_crt_list_file)
+  local max_retries=$timeout
+  local retries=1
+  while [ ! -f $ext_crt_list_file ]; do
+    echo "$(date): $ext_crt_list_file missing ($retries/$max_retries). waiting..."
+    sleep 1
+    retries=$((retries + 1))
+    if [ $retries -gt $max_retries ]; then
+      if [ $policy == "fail" ]; then
+        echo "$(date): ERROR: $ext_crt_list_file still missing after $max_retries seconds. Exiting."
+        cleanup_daemon
+        exit 1
+      fi
+      if [ $policy == "continue" ]; then
+        echo "$(date): WARNING: $ext_crt_list_file still missing after $max_retries seconds. Continuing without external certificates."
+        break
+      fi
+    fi
+  done
+  if [ -f $ext_crt_list_file ]; then
+    echo "$(date): $ext_crt_list_file found."
+  fi
+
   # merge optional external certs
   if grep -q OPTIONAL_EXT_CERTS /var/vcap/jobs/haproxy/config/ssl/crt-list; then
-    sed -i -e '/OPTIONAL_EXT_CERTS/r /var/vcap/jobs/haproxy/config/ssl/ext/crt-list' /var/vcap/jobs/haproxy/config/ssl/crt-list
+    sed -i -e '/OPTIONAL_EXT_CERTS/r <%= p("ha_proxy.ext_crt_list_file") %>' /var/vcap/jobs/haproxy/config/ssl/crt-list
   fi
+  <%- end -%>
 }
 
 # unpack base certs and add optional external certs

--- a/jobs/haproxy/templates/pre-start.erb
+++ b/jobs/haproxy/templates/pre-start.erb
@@ -8,3 +8,26 @@ cat > <%= "/var/vcap/jobs/haproxy/errorfiles/custom#{status_code}.http" %> << EO
 <%= http_content %>
 EOF
 <% end -%>
+
+<%
+if_p("ha_proxy.ext_crt_list") do |ext_crt_list|
+  if ext_crt_list
+    %>
+    mkdir -p /var/vcap/jobs/haproxy/config/ssl/ext
+    chmod o+rwx /var/vcap/jobs/haproxy/config/ssl/ext
+    max_retries=300
+    retries=0
+    while [ ! -f /var/vcap/jobs/haproxy/config/ssl/ext/crt-list ]; do
+      echo "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list missing ($retries/$max_retries). waiting..."
+      sleep 1
+      retries=$((retries + 1))
+      if [ $retries -eq $max_retries ]; then
+        echo "ERROR: /var/vcap/jobs/haproxy/config/ssl/ext/crt-list still missing after $max_retries seconds. Exiting."
+        exit 1
+      fi
+    done
+    echo "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list found."
+    <%
+  end
+end
+%>

--- a/jobs/haproxy/templates/pre-start.erb
+++ b/jobs/haproxy/templates/pre-start.erb
@@ -8,26 +8,3 @@ cat > <%= "/var/vcap/jobs/haproxy/errorfiles/custom#{status_code}.http" %> << EO
 <%= http_content %>
 EOF
 <% end -%>
-
-<%
-if_p("ha_proxy.ext_crt_list") do |ext_crt_list|
-  if ext_crt_list
-    %>
-    mkdir -p /var/vcap/jobs/haproxy/config/ssl/ext
-    chmod o+rwx /var/vcap/jobs/haproxy/config/ssl/ext
-    max_retries=300
-    retries=0
-    while [ ! -f /var/vcap/jobs/haproxy/config/ssl/ext/crt-list ]; do
-      echo "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list missing ($retries/$max_retries). waiting..."
-      sleep 1
-      retries=$((retries + 1))
-      if [ $retries -eq $max_retries ]; then
-        echo "ERROR: /var/vcap/jobs/haproxy/config/ssl/ext/crt-list still missing after $max_retries seconds. Exiting."
-        exit 1
-      fi
-    done
-    echo "/var/vcap/jobs/haproxy/config/ssl/ext/crt-list found."
-    <%
-  end
-end
-%>


### PR DESCRIPTION
This PR provides the capability to add an additional source of external certificates to HAproxy.

The major use-case is to support CF-based platforms that allow their customers to register domains  and use their own certificates. These certificates may come at any time and usually happen outside the regular BOSH deploy/update lifecycle. In conjunction with the "hitless reloads" feature (see #159 ), this allows an external service to provide an additional list of certificates and dynamically load them into HAproxy without downtime.