### PR TITLE
Update haproxy.config.erb

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -332,7 +332,7 @@ frontend https-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -408,7 +408,7 @@ frontend wss-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -249,7 +249,7 @@ frontend http-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -249,7 +249,7 @@ frontend http-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -332,7 +332,7 @@ frontend https-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
@@ -408,7 +408,7 @@ frontend wss-in
   <%- end -%>
   <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
     <%- rsp_headers.each do |rsp_header, value| -%>
-    http-response add-header <%= rsp_headers.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
+    http-response add-header <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>


### PR DESCRIPTION
Fix wrong copy/paste to `rsp_headers` property (**header.gsub** instead of **rsp_headers.gsub**)

```
  <%- if_p("ha_proxy.rsp_headers") do |rsp_headers| -%>
    <%- rsp_headers.each do |rsp_header, value| -%>
    http-response add-header <%= header.gsub(/(?!:\\)( )/, '\ ') %> "<%= value.to_s.gsub(/(?!:\\) /, '\ ') %>"
    <%- end -%>
  <%- end -%>
```