### PR TITLE
Add monit section for health check

### DIFF
--- a/jobs/haproxy/monit
+++ b/jobs/haproxy/monit
@@ -3,3 +3,18 @@ check process haproxy
   start program "/var/vcap/jobs/bpm/bin/bpm start haproxy"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop haproxy"
   group vcap
+
+<%-
+timeout=20
+if p("ha_proxy.ext_crt_list") then
+  timeout=p("ha_proxy.ext_crt_list_timeout")
+end
+-%>
+<%- if p("ha_proxy.enable_health_check_http") -%>
+check host haproxy-health address localhost
+  if failed host localhost port <%= p("ha_proxy.health_check_port") -%> protocol http
+     and request "/health"
+     with timeout <%= timeout -%> seconds for 2 cycles
+  then alert
+  group vcap
+<% end -%>


### PR DESCRIPTION
This PR fixes an issue that can occur when using the `ext_crt_list` feature with `ext_crt_list_policy` set to `fail`.
If loading the additional certificates does not work in time, the HAproxy won't be started. However, from monits perspective it is running because monit only watches the `haproxy_wrapper` script (which is doing the timeout and waiting for certificates).

So if there is a persistent issue with the external certificates not getting delivered, BOSH will end up deploying all HAproxy instances, none of which are actually running in the end, thus producing an outage.

The fix to this problem is to watch not just the process but also if you can actually talk to the proxy. We accomplish this by checking the http health port in addition to the pid.