### PR TITLE
Hatop python fix

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -3,9 +3,8 @@ haproxy/haproxy-2.2.5.tar.gz:
   object_id: 14319fe5-f669-4485-6b7f-b0d66593af38
   sha: c2d805b4923e065c503d330ff84633d2a194d399
 haproxy/hatop:
-  size: 72429
-  object_id: d86cd983-5ca3-4293-6620-56a9273be80f
-  sha: daddb3f13a70d4e2fa0802333c2e13468635171f
+  size: 72445
+  sha: sha256:a58450560686a429bfd6b3c8732f68f9043fa5ef2be5fac0218f48babfe57cbf
 haproxy/lua-5.4.1.tar.gz:
   size: 353965
   object_id: bbdf988e-4504-49ea-5d88-49adb3488e96

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -4,6 +4,7 @@ haproxy/haproxy-2.2.5.tar.gz:
   sha: c2d805b4923e065c503d330ff84633d2a194d399
 haproxy/hatop:
   size: 72445
+  object_id: 17a5f66c-bbc1-4e4d-681c-e36420d3e0f5
   sha: sha256:a58450560686a429bfd6b3c8732f68f9043fa5ef2be5fac0218f48babfe57cbf
 haproxy/lua-5.4.1.tar.gz:
   size: 353965

--- a/jobs/haproxy/templates/pre-start.erb
+++ b/jobs/haproxy/templates/pre-start.erb
@@ -8,3 +8,11 @@ cat > <%= "/var/vcap/jobs/haproxy/errorfiles/custom#{status_code}.http" %> << EO
 <%= http_content %>
 EOF
 <% end -%>
+
+if [ ! -e /usr/bin/python ] && [ -e /usr/bin/python3 ]; then
+  sudo ln -s /usr/bin/python3 /usr/bin/python
+fi
+
+if [ ! -e /usr/local/bin/hatop ]; then
+  sudo ln -s /var/vcap/packages/haproxy/hatop-wrapper /usr/local/bin/hatop
+fi

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -31,6 +31,7 @@ pushd socat-${SOCAT_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/socat
 popd
 
+echo "Installing HAproxy..."
 tar xf haproxy/haproxy-${HAPROXY_VERSION}.tar.gz
 pushd haproxy-${HAPROXY_VERSION}
   make TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_PCRE2_JIT=yes USE_STATIC_PCRE2=1 USE_ZLIB=1 PCRE2DIR=${BOSH_INSTALL_TARGET} USE_LUA=1 LUA_LIB=${BOSH_INSTALL_TARGET}/lib LUA_INC=${BOSH_INSTALL_TARGET}/include
@@ -38,6 +39,7 @@ pushd haproxy-${HAPROXY_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
 popd
 
+echo "Installing hatop..."
 cp haproxy/hatop ${BOSH_INSTALL_TARGET}/bin/hatop
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/hatop
 cp hatop-wrapper ${BOSH_INSTALL_TARGET}/


### PR DESCRIPTION
Fixes #160 

- Update hatop to v0.8 to provide support for python3
- Add symlink to hatop-wrapper for convenience
- Add symlink to python3 in case only python3 exists
