### PR TITLE
New Mutual TLS setting compatible with CF Route Services

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -317,7 +317,7 @@ properties:
     description: |
       This option lets you decide how to handle the X-Forwarded-Client-Cert (XFCC) http header on any https frontend.
       On http frontends the `always_forward_only` option is active by default and can't be changed.
-      On https frontends your options are (ordered from least to most secure):
+      On https frontends your options are:
       - always_forward_only:
           Least secure option. Always forward the XFCC header in the request, regardless of whether the client connection is mTLS.
           Use this value when your load balancer is forwarding the client certificate and requests are not forwarded to HAProxy over mTLS.
@@ -329,6 +329,11 @@ properties:
           Most secure option. Strip any instances of XFCC headers from the client request.
           When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in this header.
           Values will be base64 encoded PEM. Use this value when HAProxy is the first component to terminate TLS.
+      - forward_only_if_route_service:
+          This option is useful to support Mutual TLS with CF Route Services.
+          When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in the XFCC header.
+          When the client connection is not mTLS, the XFCC header will be removed UNLESS there is an X-Cf-Proxy-Signature header.
+          This option is only secure if Gorouter is deployed behind Haproxy to validate that X-Cf-Proxy-Signature is coming from a route service.
     default: sanitize_set
 
   ha_proxy.client_ca_file:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -99,7 +99,7 @@ when "sanitize_set"
 when "forward_only_if_route_service"
   xfcc_forward_only_if_route_service = true
 else
-  abort("Unkown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set'")
+  abort("Unknown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set', 'forward_only_if_route_service'")
 end
 # }}}
 # IPv4 and IPv6 binding (v4v6) Option {{{

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -86,6 +86,7 @@ tls_bind_options = "ssl #{tls_options}"
 # X-Forwarded-Client-Cert (XFCC) Option {{{
 xfcc_forward_only = false
 xfcc_sanitize_set = false
+xfcc_forward_only_if_route_service = false
 
 forwarded_client_cert_option = p("ha_proxy.forwarded_client_cert").downcase
 case forwarded_client_cert_option
@@ -95,6 +96,8 @@ when "forward_only"
   xfcc_forward_only = true
 when "sanitize_set"
   xfcc_sanitize_set = true
+when "forward_only_if_route_service"
+  xfcc_forward_only_if_route_service = true
 else
   abort("Unkown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set'")
 end
@@ -313,6 +316,10 @@ frontend https-in
     <%- if mutual_tls_enabled then -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
     <%- end -%>
+  <%- elsif xfcc_forward_only_if_route_service then -%>
+    acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
+    http-request del-header X-Forwarded-Client-Cert if !route_service_request
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>


### PR DESCRIPTION
We have Haproxy terminating TLS and then Gorouter behind Haproxy. We want to use Mutual TLS with Route Services. Right now this is broken, because Gorouter makes an external request to the route service, and Haproxy's `sanitize_set` option strips off the `X-Forwarded-Client-Cert` header.

This commit adds a new setting `forwarded_client_cert: forward_only_if_route_service`. In this mode Haproxy will preserve X-Forwarded-Client-Cert headers if there is also a X-Cf-Proxy-Signature header provided.

The security of this is based on Gorouter verifying the contents of the X-Cf-Proxy-Signature header. [Gorouter checks the contents of that header and rejects the request if it did not come from a CF Route Service](https://docs.cloudfoundry.org/services/route-services.html#x-cf-proxy-signature) (this works both for `Gorouter->Route Service` and `Route Service->Gorouter`.)