### PR TITLE
Implement ACL acceptance tests

### DIFF
--- a/acceptance-tests/acceptance_tests_suite_test.go
+++ b/acceptance-tests/acceptance_tests_suite_test.go
@@ -50,3 +50,13 @@ func setupTunnelFromHaproxyToTestServer(haproxyInfo haproxyInfo, haproxyBackendP
 
 	return cancelFunc
 }
+
+// Sets up SSH tunnel from local machine to HAProxy
+func setupTunnelFromLocalMachineToHAProxy(haproxyInfo haproxyInfo, localPort, haproxyPort int) func() {
+	By(fmt.Sprintf("Creating a SSH tunnel from localmachine (port %d) to HAProxy (port %d)", localPort, haproxyPort))
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	err := startSSHPortForwarder(haproxyInfo.SSHUser, haproxyInfo.PublicIP, haproxyInfo.SSHPrivateKey, localPort, haproxyPort, ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	return cancelFunc
+}

--- a/acceptance-tests/access_control_test.go
+++ b/acceptance-tests/access_control_test.go
@@ -1,0 +1,104 @@
+package acceptance_tests
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+/*
+	Test strategy:
+		* Use an SSH tunnel to make requests to HAProxy that appear to come from 127.0.0.1
+		* Requests directly from test runner on Concourse appear to come from 10.0.0.0/8
+		We can test whitelisting and blacklisting by using these CIDRs
+*/
+var _ = Describe("Access Control", func() {
+	opsfileWhitelist := `---
+# Enable CIDR whitelist
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/cidr_whitelist?
+  value: ((cidr_whitelist))
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/block_all?
+  value: true
+`
+	opsfileBlacklist := `---
+# Enable CIDR blacklist
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/cidr_blacklist?
+  value: ((cidr_blacklist))
+`
+
+	It("Allows IPs in whitelisted CIDRS", func() {
+		deploymentName := "haproxy"
+		haproxyBackendPort := 12000
+
+		// Allow 127.0.0.1/32, but deny other connections
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    12000,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileWhitelist}, map[string]interface{}{
+			"cidr_whitelist": []string{"127.0.0.1/32"},
+		}, true)
+		defer deleteDeployment(deploymentName)
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeBackendTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeBackendTunnel()
+
+		// Set up a tunnel so that requests to localhost:11000 appear to come from 127.0.0.1
+		// on the HAProxy VM as this is now whitelisted
+		closeFrontendTunnel := setupTunnelFromLocalMachineToHAProxy(haproxyInfo, 11000, 80)
+		defer closeFrontendTunnel()
+
+		By("Denying access from non-whitelisted CIDRs (request from test runner)")
+		_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+		Expect(err.Error()).To(ContainSubstring("EOF")) // when denying HAProxy returns an empty response
+
+		By("Allowing access to whitelisted CIDRs (request from 127.0.0.1 on HAProxy VM)")
+		resp, err := http.Get("http://127.0.0.1:11000")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("Rejects IPs in blacklisted CIDRS", func() {
+		deploymentName := "haproxy"
+		haproxyBackendPort := 12000
+
+		// Allow 127.0.0.1/32, but deny other connections
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    12000,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileBlacklist}, map[string]interface{}{
+			// traffic from test runner appears to come from this CIDR block
+			"cidr_blacklist": []string{"10.0.0.0/8"},
+		}, true)
+		defer deleteDeployment(deploymentName)
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeBackendTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeBackendTunnel()
+
+		// Set up a tunnel so that requests to localhost:11000 appear to come from 127.0.0.1
+		// on the HAProxy VM as this is now blacklisted
+		closeFrontendTunnel := setupTunnelFromLocalMachineToHAProxy(haproxyInfo, 11000, 80)
+		defer closeFrontendTunnel()
+
+		By("Denying access from blacklisted CIDRs (request from test runner)")
+		_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+		Expect(err.Error()).To(ContainSubstring("EOF")) // when denying HAProxy returns an empty response
+
+		By("Allowing access to non-blacklisted CIDRs (request from 127.0.0.1 on HAProxy VM)")
+		resp, err := http.Get("http://127.0.0.1:11000")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+})

--- a/acceptance-tests/access_control_test.go
+++ b/acceptance-tests/access_control_test.go
@@ -1,7 +1,9 @@
 package acceptance_tests
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
@@ -58,7 +60,8 @@ var _ = Describe("Access Control", func() {
 
 		By("Denying access from non-whitelisted CIDRs (request from test runner)")
 		_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
-		Expect(err.Error()).To(ContainSubstring("EOF")) // when denying HAProxy returns an empty response
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, io.EOF)).To(BeTrue())
 
 		By("Allowing access to whitelisted CIDRs (request from 127.0.0.1 on HAProxy VM)")
 		resp, err := http.Get("http://127.0.0.1:11000")
@@ -94,7 +97,8 @@ var _ = Describe("Access Control", func() {
 
 		By("Denying access from blacklisted CIDRs (request from test runner)")
 		_, err := http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
-		Expect(err.Error()).To(ContainSubstring("EOF")) // when denying HAProxy returns an empty response
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, io.EOF)).To(BeTrue())
 
 		By("Allowing access to non-blacklisted CIDRs (request from 127.0.0.1 on HAProxy VM)")
 		resp, err := http.Get("http://127.0.0.1:11000")

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -418,7 +418,7 @@ properties:
       - 10.0.0.0/8
       - 192.168.2.0/24
   ha_proxy.cidr_whitelist:
-    description: "List of CIDRs to allow for http(s). Format is string array of CIDRs or single string of base64 encoded gzip."
+    description: "List of CIDRs to allow for http(s). Format is string array of CIDRs or single string of base64 encoded gzip. Note that unless ha_proxy.block_all is true, non-whitelisted traffic will still be allowed, provided that traffic is not also blacklisted"
     default: ~
     example:
       cidr_whitelist:


### PR DESCRIPTION
~Requires https://github.com/cloudfoundry-incubator/haproxy-boshrelease/pull/198 is merged first~

Implement acceptance tests for `ha_proxy.cidr_whitelist` and `ha_proxy.cidr_blacklist` properties
Also clarifies the spec description for `ha_proxy.cidr_whitelist`

