### PR TITLE
Ensure that deployment fails when enable_health_check_http: true and there are no healthy backends

### DIFF
--- a/acceptance-tests/config.go
+++ b/acceptance-tests/config.go
@@ -80,7 +80,7 @@ func loadConfig() (Config, error) {
 	}, nil
 }
 
-func (config *Config) boshCmd(args ...string) *exec.Cmd {
+func (config *Config) boshCmd(boshDeployment string, args ...string) *exec.Cmd {
 	cmd := exec.Command(config.BoshPath, args...)
 	cmd.Env = []string{
 		fmt.Sprintf("BOSH_CA_CERT=%s", config.BoshCACert),
@@ -88,8 +88,8 @@ func (config *Config) boshCmd(args ...string) *exec.Cmd {
 		fmt.Sprintf("BOSH_CLIENT_SECRET=%s", config.BoshClientSecret),
 		fmt.Sprintf("BOSH_ENVIRONMENT=%s", config.BoshEnvironment),
 		fmt.Sprintf("HOME=%s", config.HomePath),
+		fmt.Sprintf("BOSH_DEPLOYMENT=%s", boshDeployment),
 		"BOSH_NON_INTERACTIVE=true",
-		"BOSH_DEPLOYMENT=haproxy",
 	}
 
 	return cmd

--- a/acceptance-tests/healthcheck_test.go
+++ b/acceptance-tests/healthcheck_test.go
@@ -11,29 +11,26 @@ import (
 )
 
 var _ = Describe("HTTP Health Check", func() {
-	AfterEach(func() {
-		deleteDeployment()
-	})
-
-	It("Correctly fails to start if there is no healthy backend", func() {
-		opsfileHTTPHealthcheck := `---
+	opsfileHTTPHealthcheck := `---
 # Enable health check
 - type: replace
   path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/enable_health_check_http?
   value: true
 `
-		haproxyBackendPort := 12000
-		haproxyInfo, _ := deployHAProxy(haproxyBackendPort, []string{opsfileHTTPHealthcheck}, map[string]interface{}{})
 
-		// FIXME: this behaviour will change once https://github.com/cloudfoundry-incubator/haproxy-boshrelease/issues/195
-		// is fixed
-		By("Waiting monit to report HAProxy is now unhealthy (due to no healthy backend instances)")
-		// BOSH initially thinks that the process is healthy, but later switches to 'failing' when
-		// monit reports the failing health check due to no healthy backend instances.
-		// We will up to wait one minute for the status to stabilise
-		Eventually(func() string {
-			return boshInstances()[0].ProcessState
-		}, time.Minute, time.Second).Should(Equal("failing"))
+	It("Correctly fails to start if there is no healthy backend", func() {
+		deploymentName := "haproxy"
+		haproxyBackendPort := 12000
+		// Expect initial deployment to be failing due to lack of healthy backends
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileHTTPHealthcheck}, map[string]interface{}{}, false)
+		defer deleteDeployment(deploymentName)
+
+		// Verify that is in a failing state
+		Expect(boshInstances(deploymentName)[0].ProcessState).To(Or(Equal("failing"), Equal("unresponsive agent")))
 
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()
@@ -42,12 +39,54 @@ var _ = Describe("HTTP Health Check", func() {
 		defer closeTunnel()
 
 		By("Waiting monit to report HAProxy is now healthy (due to having a healthy backend instance)")
-		// Since the backend is listening, HAProxy healthcheck should start returning healthy
+		// Since the backend is now listening, HAProxy healthcheck should start returning healthy
 		// and monit should in turn start reporting a healthy process
 		// We will up to wait one minute for the status to stabilise
 		Eventually(func() string {
-			return boshInstances()[0].ProcessState
+			return boshInstances(deploymentName)[0].ProcessState
 		}, time.Minute, time.Second).Should(Equal("running"))
+
+		By("The healthcheck health endpoint should report a 200 status code")
+		resp, err := http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("Sending a request to HAProxy works")
+		resp, err = http.Get(fmt.Sprintf("http://%s", haproxyInfo.PublicIP))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
+
+	})
+
+	It("Correctly starts if there is a healthy backend", func() {
+		backendDeploymentName := "haproxy-backend"
+		// For this test we will use a second HAProxy as pre-existing healthy 'backend'
+		haproxyBackendPort := 12000
+		backendHaproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        backendDeploymentName,
+		}, []string{}, map[string]interface{}{}, true)
+		defer deleteDeployment(backendDeploymentName)
+
+		closeLocalServer, backendLocalPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(backendHaproxyInfo, haproxyBackendPort, backendLocalPort)
+		defer closeTunnel()
+
+		// Now deploy test HAProxy with 'haproxy-backend' configured as backend
+		deploymentName := "haproxy"
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    80,
+			haproxyBackendServers: []string{backendHaproxyInfo.PublicIP},
+			deploymentName:        deploymentName,
+		}, []string{opsfileHTTPHealthcheck}, map[string]interface{}{}, true)
+		defer deleteDeployment(deploymentName)
+
+		// Verify that instance is in a running state
+		Expect(boshInstances(deploymentName)[0].ProcessState).To(Equal("running"))
 
 		By("The healthcheck health endpoint should report a 200 status code")
 		resp, err := http.Get(fmt.Sprintf("http://%s:8080/health", haproxyInfo.PublicIP))

--- a/acceptance-tests/http_frontend_test.go
+++ b/acceptance-tests/http_frontend_test.go
@@ -10,13 +10,19 @@ import (
 )
 
 var _ = Describe("HTTP Frontend", func() {
+	deploymentName := "haproxy"
+
 	AfterEach(func() {
-		deleteDeployment()
+		deleteDeployment(deploymentName)
 	})
 
 	It("Correctly proxies HTTP requests", func() {
 		haproxyBackendPort := 12000
-		haproxyInfo, _ := deployHAProxy(haproxyBackendPort, []string{}, map[string]interface{}{})
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{}, map[string]interface{}{}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()

--- a/acceptance-tests/https_ext_crt_list.go
+++ b/acceptance-tests/https_ext_crt_list.go
@@ -28,8 +28,10 @@ import (
 */
 
 var _ = Describe("External Certificate Lists", func() {
+	deploymentName := "haproxy"
+
 	AfterEach(func() {
-		deleteDeployment()
+		deleteDeployment(deploymentName)
 	})
 
 	It("Uses the correct certs", func() {
@@ -99,9 +101,13 @@ var _ = Describe("External Certificate Lists", func() {
 
 		haproxyBackendPort := 12000
 		extCrtListPath := "/var/vcap/jobs/haproxy/config/ssl/ext-crt-list"
-		haproxyInfo, varsStoreReader := deployHAProxy(haproxyBackendPort, []string{opsfileSSLCertificate}, map[string]interface{}{
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileSSLCertificate}, map[string]interface{}{
 			"ext_crt_list_path": extCrtListPath,
-		})
+		}, true)
 
 		var creds struct {
 			CertA struct {

--- a/acceptance-tests/https_frontend_test.go
+++ b/acceptance-tests/https_frontend_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 var _ = Describe("HTTPS Frontend", func() {
+	deploymentName := "haproxy"
+
 	AfterEach(func() {
-		deleteDeployment()
+		deleteDeployment(deploymentName)
 	})
 
 	It("Correctly proxies HTTPS requests", func() {
@@ -46,7 +48,11 @@ var _ = Describe("HTTPS Frontend", func() {
 `
 
 		haproxyBackendPort := 12000
-		haproxyInfo, varsStoreReader := deployHAProxy(haproxyBackendPort, []string{opsfileSSLCertificate}, map[string]interface{}{})
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileSSLCertificate}, map[string]interface{}{}, true)
 
 		var creds struct {
 			HTTPSFrontend struct {

--- a/acceptance-tests/tcp_frontend_test.go
+++ b/acceptance-tests/tcp_frontend_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 var _ = Describe("TCP Frontend", func() {
+	deploymentName := "haproxy"
+
 	AfterEach(func() {
-		deleteDeployment()
+		deleteDeployment(deploymentName)
 	})
 
 	It("Correctly proxies TCP requests", func() {
@@ -28,10 +30,14 @@ var _ = Describe("TCP Frontend", func() {
 `
 		tcpFrontendPort := 13000
 		tcpBackendPort := 13001
-		haproxyInfo, _ := deployHAProxy(12000, []string{opsfileTCP}, map[string]interface{}{
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    12000,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileTCP}, map[string]interface{}{
 			"tcp_frontend_port": tcpFrontendPort,
 			"tcp_backend_port":  tcpBackendPort,
-		})
+		}, true)
 
 		closeLocalServer, localPort := startDefaultTestServer()
 		defer closeLocalServer()

--- a/acceptance-tests/xfcc_test.go
+++ b/acceptance-tests/xfcc_test.go
@@ -30,6 +30,8 @@ import (
 																		 X-Forwarded-Client-Cert is overwritten for mTLS connections
 */
 var _ = Describe("forwarded_client_cert", func() {
+	deploymentName := "haproxy"
+
 	opsfileForwardedClientCert := `---
 # Configure X-Forwarded-Client-Cert handling
 - type: replace
@@ -110,7 +112,7 @@ var _ = Describe("forwarded_client_cert", func() {
 	recordedXFCCHeader := "initial"
 
 	AfterEach(func() {
-		defer deleteDeployment()
+		defer deleteDeployment(deploymentName)
 
 		if closeLocalServer != nil {
 			defer closeLocalServer()
@@ -124,7 +126,11 @@ var _ = Describe("forwarded_client_cert", func() {
 	JustBeforeEach(func() {
 		haproxyBackendPort := 12000
 		var varsStoreReader varsStoreReader
-		haproxyInfo, varsStoreReader = deployHAProxy(haproxyBackendPort, []string{opsfileForwardedClientCert}, deployVars)
+		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentName,
+		}, []string{opsfileForwardedClientCert}, deployVars, true)
 
 		err := varsStoreReader(&creds)
 		Expect(err).NotTo(HaveOccurred())

--- a/jobs/haproxy/monit
+++ b/jobs/haproxy/monit
@@ -10,11 +10,13 @@ if p("ha_proxy.ext_crt_list") then
   timeout=p("ha_proxy.ext_crt_list_timeout")
 end
 -%>
+
 <%- if p("ha_proxy.enable_health_check_http") -%>
 check host haproxy-health address localhost
+  depends on haproxy
   if failed host localhost port <%= p("ha_proxy.health_check_port") -%> protocol http
      and request "/health"
-     with timeout <%= timeout -%> seconds for 2 cycles
+     with timeout <%= timeout -%> seconds
   then alert
   group vcap
 <% end -%>

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -176,7 +176,7 @@ properties:
   ha_proxy.backend_ca_file:
     description: "Optional SSL CA certificate chain (PEM file) concatenated together for backend SSL servers, only used when one of the `backend_ssl` options is set to `verify`"
   ha_proxy.enable_health_check_http:
-    description: "Optionally enable http health-check on `haproxy_ip:8080/health`. It shows `200 OK` if >0 backend servers are up."
+    description: "Optionally enable http health-check on `haproxy_ip:8080/health`. It shows `200 OK` if >0 backend servers are up. If used with ext_crt_list_timeout you should make sure that the deployment canary_watch_time and update_watch_time are configured to wait at least the number of seconds defined by ext_crt_list_timeout."
     default: false
   ha_proxy.health_check_port:
     description: "port for http health-check"
@@ -379,7 +379,7 @@ properties:
   ha_proxy.tcp_link_port:
     description: "Port haproxy should listen on when using the tcp_backend link"
   ha_proxy.tcp_link_check_port:
-    description: "Optional port for tcp_backend health checks. Will use ha_proxy.tcp_link_port if not set."  
+    description: "Optional port for tcp_backend health checks. Will use ha_proxy.tcp_link_port if not set."
   ha_proxy.tcp_link_health_check_http:
     description: "Optional port for http health check when using the tcp_backend link."
   ha_proxy.resolvers:


### PR DESCRIPTION
Fixes #195 

Requires https://github.com/cloudfoundry-incubator/haproxy-boshrelease/pull/192 is merged first

With this change deployments with unhealthy backends will fail with:

```
Task 6 | 12:30:42 | L starting jobs: haproxy/aff24934-0f1c-4cb4-8061-8654b8206eb1 (0) (canary) (00:00:40)
                  L Error: 'haproxy/aff24934-0f1c-4cb4-8061-8654b8206eb1 (0)' is not running after update. Review logs for failed jobs: haproxy-health
Task 6 | 12:31:14 | Error: 'haproxy/aff24934-0f1c-4cb4-8061-8654b8206eb1 (0)' is not running after update. Review logs for failed jobs: haproxy-health
```