### PR TITLE
Add acceptance tests for `ext_crt_list_policy: fail` and fix cert packing bug

### DIFF
--- a/ci/scripts/lint
+++ b/ci/scripts/lint
@@ -6,3 +6,7 @@ cd ${REPO_ROOT}
 
 bundle package
 bundle exec rake lint
+
+pushd acceptance-tests
+  go vet
+popd

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -148,7 +148,8 @@ properties:
       A flag denoting the use of additional certificates from external sources.
       If set to true the contents of an external crt-list file located at `ha_proxy.ext_crt_list_file` are
       added to the crt-list described by the `ha_proxy.crt_list` property. Please be aware that reloading external certificates does only work if haproxy is
-      started in daemon mode. So this feature does not work if "haproxy.syslog_server" is set to "stdout".
+      started in daemon mode. So this feature does not work if "haproxy.syslog_server" is set to "stdout". If using this feature but not using internal certs,
+      you should set ha_proxy.crt_list to be an empty array
     default: false
   ha_proxy.ext_crt_list_file:
     description: |

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -67,7 +67,11 @@ if_p("ha_proxy.crt_list") do |crt_list|
 %>/var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem<%= sslbindconf %><%= snifilter%>
 <%
   end
-
+%>
+<%- if p("ha_proxy.ext_crt_list") == true -%>
+#OPTIONAL_EXT_CERTS
+<%- end -%>
+<%
   crt_list.each_with_index do |list_entry, i|
     pem_block = list_entry["ssl_pem"];
     client_ca_file=""
@@ -75,9 +79,6 @@ if_p("ha_proxy.crt_list") do |crt_list|
       pem_block = pem_block['cert_chain'].strip + "\n" + pem_block['private_key'].strip
     end
 %>
-<% if p("ha_proxy.ext_crt_list") == true %>
-#OPTIONAL_EXT_CERTS
-<% end %>
 ========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
 <%= pem_block %>
 <%

--- a/spec/haproxy/templates/certs.ttar_spec.rb
+++ b/spec/haproxy/templates/certs.ttar_spec.rb
@@ -396,8 +396,6 @@ describe 'config/certs.ttar' do
       let(:ttar) do
         template.render({
           'ha_proxy' => {
-            # FIXME: using ext_crt_list: true currently requires crt_list is [], not nil
-            # if there are no 'internal' certs but probably shouldn't require this
             'crt_list' => [],
             'ext_crt_list' => true
           }

--- a/spec/haproxy/templates/certs.ttar_spec.rb
+++ b/spec/haproxy/templates/certs.ttar_spec.rb
@@ -392,27 +392,66 @@ describe 'config/certs.ttar' do
   end
 
   describe 'ha_proxy.ext_crt_list' do
-    let(:ttar) do
-      template.render({
-        'ha_proxy' => {
-          'crt_list' => [{
-            'ssl_pem' => 'ssl_pem contents'
-          }],
-          'ext_crt_list' => true
-        }
-      })
+    context 'when there are no internal certificates' do
+      let(:ttar) do
+        template.render({
+          'ha_proxy' => {
+            # FIXME: using ext_crt_list: true currently requires crt_list is [], not nil
+            # if there are no 'internal' certs but probably shouldn't require this
+            'crt_list' => [],
+            'ext_crt_list' => true
+          }
+        })
+      end
+
+      it 'is referenced in the crt list' do
+        expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/crt-list')).to eq(<<~EXPECTED)
+
+
+          #OPTIONAL_EXT_CERTS
+
+        EXPECTED
+      end
     end
 
-    # FIXME: is there a nicer way than using sed for this?
-    it 'is referenced in the crt list' do
-      expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/crt-list')).to eq(<<~EXPECTED)
+    context 'when there are also internal certificates' do
+      let(:ttar) do
+        template.render({
+          'ha_proxy' => {
+            'crt_list' => [{
+              'ssl_pem' => 'ssl_pem 0 contents'
+            }, {
+              'ssl_pem' => 'ssl_pem 1 contents'
+            }],
+            'ext_crt_list' => true
+          }
+        })
+      end
 
-        /var/vcap/jobs/haproxy/config/ssl/cert-0.pem
+      it 'is referenced in the crt list' do
+        expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/crt-list')).to eq(<<~EXPECTED)
 
+          /var/vcap/jobs/haproxy/config/ssl/cert-0.pem
+          /var/vcap/jobs/haproxy/config/ssl/cert-1.pem
 
-        #OPTIONAL_EXT_CERTS
+          #OPTIONAL_EXT_CERTS
 
-      EXPECTED
+        EXPECTED
+      end
+
+      it 'has the correct internal certificate contents' do
+        expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/cert-0.pem')).to eq(<<~EXPECTED)
+
+          ssl_pem 0 contents
+
+        EXPECTED
+
+        expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/cert-1.pem')).to eq(<<~EXPECTED)
+
+          ssl_pem 1 contents
+
+        EXPECTED
+      end
     end
   end
 


### PR DESCRIPTION
~**Requires #204 is merged first**~

* Uses os-conf to add an "external cert" during the pre-start deploy stage
* Also adds linting for acceptance-tests
* Also fixes bug that causes invalid cert bundles when there is more than one `crt_list` entry and `ext_crt_list` is present