### PR TITLE
Test ext_crt_policy fail with delayed external certificate installation

### DIFF
--- a/acceptance-tests/config.go
+++ b/acceptance-tests/config.go
@@ -81,7 +81,7 @@ func loadConfig() (Config, error) {
 }
 
 func (config *Config) boshCmd(boshDeployment string, args ...string) *exec.Cmd {
-	cmd := exec.Command(config.BoshPath, args...)
+	cmd := exec.Command(config.BoshPath, append([]string{"--tty", "--no-color"}, args...)...)
 	cmd.Env = []string{
 		fmt.Sprintf("BOSH_CA_CERT=%s", config.BoshCACert),
 		fmt.Sprintf("BOSH_CLIENT=%s", config.BoshClient),


### PR DESCRIPTION
~**Requires #206 is merged first**~

Verifies that external certificates installed _after_ monit starts the HAPRoxy wrapper script but before _ ext_crt_list_timeout_ expires work correctly