### PR TITLE
Miscellaneous UX improvements

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -186,7 +186,7 @@ properties:
     description: "Disable port 80 traffic"
     default: false
   ha_proxy.enable_4443:
-    description: "Enables port 4443 for backwards compatibility with WSS-based apps using the old CF haproxy"
+    description: "Enables port 4443 for backwards compatibility with WSS-based apps using the old CF haproxy. If true you must provide a valid SSL config via ssl_pem or crt_list"
     default: false
   ha_proxy.https_redirect_domains:
     description: "For each domain in this array, a HTTPS redirect rule will be put in the config file. Redirect will be applied for all subdomains"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -313,7 +313,7 @@ properties:
         MyCustomHeader: 3
 
   ha_proxy.backend_crt:
-    description: "provides client certificate to backend server to do mutual ssl"
+    description: "Provides client certificate to backend server to do mutual ssl. Note this only configures the client cert for HTTP backends configured via the backend_servers property or through BOSH links. It is not used with backend servers configured via routed_backend_servers or TCP backends"
     example: |
       -----BEGIN CERTIFICATE-----
       ******

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -66,7 +66,7 @@ properties:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []
   ha_proxy.trusted_domain_cidrs:
-    description: "Space separated trusted cidr blocks for internal_only_domains"
+    description: "Space separated trusted cidr blocks for internal_only_domains. You may alternatively provide a base64-encoded gzipped HAProxy cidr file, with each CIDR on a new line."
     default: 0.0.0.0/32
   ha_proxy.strict_sni:
     description: "Optional setting to decide whether the SSL/TLS negotiation is allowed only if the client provided an SNI which strict match a certificate. If set to true, the default certificate is not used"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -375,6 +375,8 @@ properties:
           backend_servers: # required - list of backend IPs to connect to
           - 10.20.10.10
           - 10.20.10.11
+          backend_servers_local: # optional - list of backend IPs which have priority routing (for example those in the same AZ). IPs must also be included in backend_servers.
+          - 10.20.10.10
           balance: roundrobin # optional - sets algorithm used to select a server when doing load balancing
           backend_port: 80 # optional - sets backend port - otherwise defaults to `port`
           ssl: true        # optional - enables ssl, and uses the `ha_proxy.ssl_pem` provided key
@@ -549,7 +551,7 @@ properties:
     default: 0
   ha_proxy.backend_prefer_local_az:
     description: |
-      Prefer backend servers which are located on the same availability zone
+      Prefer backend servers which are located on the same availability zone. Note that this only affects servers provided via the http_backend link property. Servers provided via the tcp backend_link will automatically prefer the local AZ.
     default: false
   ha_proxy.enable_http2:
     description: Enables ingress and egress HTTP/2 ALPN negotiation

--- a/jobs/haproxy/templates/blacklist_cidrs.txt.erb
+++ b/jobs/haproxy/templates/blacklist_cidrs.txt.erb
@@ -6,7 +6,7 @@ require 'stringio'
 
 if_p("ha_proxy.cidr_blacklist") do |cidrs|
   uncompressed = ''
-  if cidrs.is_a?(Array) then
+  if cidrs.is_a?(Array)
     uncompressed << "\# detected cidrs provided as array in cleartext format\n"
     cidrs.each do |cidr|
       uncompressed << cidr << "\n"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -2,36 +2,6 @@
 <%= p("ha_proxy.raw_config") %>
 <%- else -%>
 <%-
-  # Error checking
-  if !p("ha_proxy.drain_enable", false) && p("ha_proxy.drain_frontend_grace_time") > 0
-    abort "Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time"
-  end
-
-  if !p("ha_proxy.hsts_enable", false)
-    if p("ha_proxy.hsts_include_subdomains")
-      abort "Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains"
-    end
-    if p("ha_proxy.hsts_preload")
-      abort "Conflicting configuration: hsts_enable must be true to enable hsts_preload"
-    end
-  end
-
-  if p("ha_proxy.backend_ssl", "").downcase != "verify"
-    if p("ha_proxy.backend_ssl_verifyhost", false)
-      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost"
-    end
-  end
-
-  if !p("ha_proxy.client_cert", nil)
-    if p("ha_proxy.client_cert_ignore_err", false)
-      abort "Conflicting configuration: must provide client_cert to use client_cert_ignore_err"
-    end
-
-    if p("ha_proxy.client_revocation_list", false)
-      abort "Conflicting configuration: must provide client_cert to use client_revocation_list"
-    end
-  end
-
 require "digest"
 # Ruby Variables to make the template more readable
 
@@ -148,6 +118,40 @@ if p("ha_proxy.enable_http2")
   alpn_config = "alpn h2,http/1.1 "
 end
 # }}}
+
+# Error checking
+  if !p("ha_proxy.drain_enable", false) && p("ha_proxy.drain_frontend_grace_time") > 0
+    abort "Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time"
+  end
+
+  if !p("ha_proxy.hsts_enable", false)
+    if p("ha_proxy.hsts_include_subdomains")
+      abort "Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains"
+    end
+    if p("ha_proxy.hsts_preload")
+      abort "Conflicting configuration: hsts_enable must be true to enable hsts_preload"
+    end
+  end
+
+  if p("ha_proxy.backend_ssl", "").downcase != "verify"
+    if p("ha_proxy.backend_ssl_verifyhost", false)
+      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost"
+    end
+  end
+
+  if !p("ha_proxy.client_cert", nil)
+    if p("ha_proxy.client_cert_ignore_err", false)
+      abort "Conflicting configuration: must enable client_cert to use client_cert_ignore_err"
+    end
+
+    if p("ha_proxy.client_revocation_list", false)
+      abort "Conflicting configuration: must enable client_cert to use client_revocation_list"
+    end
+  end
+
+  if p("ha_proxy.enable_4443") && !ssl_enabled
+    abort "Conflicting configuration: if enable_4443 is true, you must provide a valid SSL config via ssl_pem or crt_list"
+  end
 -%>
 
 global

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -330,7 +330,16 @@ frontend https-in
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
-  <%- end -%>
+  <%-
+    else
+      if p("ha_proxy.hsts_include_subdomains")
+        abort "Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains"
+      end
+      if p("ha_proxy.hsts_preload")
+        abort "Conflicting configuration: hsts_enable must be true to enable hsts_preload"
+      end
+    end
+  -%>
     capture request header Host len 256
     default_backend http-routers
   <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -488,6 +488,13 @@ backend http-routers
     backend_crt = "crt /var/vcap/jobs/haproxy/config/backend-crt.pem "
   end
   backend_ssl = ""
+
+  if (p("ha_proxy.backend_ssl") || "").downcase != "verify"
+    if_p("ha_proxy.backend_ssl_verifyhost") do |_|
+      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost"
+    end
+  end
+
   if p("ha_proxy.backend_ssl").downcase == "verify"
     backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
     if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname |
@@ -527,6 +534,13 @@ backend http-routed-backend-<%= prefix_hash %>
     resolvers = "resolvers default "
   end
   backend_ssl = ""
+
+  if (data["backend_ssl"] || "").downcase != "verify"
+    if data["backend_verifyhost"]
+      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_verifyhost in routed_backend_servers"
+    end
+  end
+
   if data["backend_ssl"]
     if data["backend_ssl"].downcase == "verify"
       backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
@@ -622,6 +636,13 @@ backend tcp-<%= tcp_proxy["name"] %>
     resolvers = "resolvers default "
   end
   backend_ssl = ""
+
+  if (tcp_proxy["backend_ssl"] || "").downcase != "verify"
+    if tcp_proxy["backend_verifyhost"]
+      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_verifyhost in tcp backend configuration"
+    end
+  end
+
   if tcp_proxy["backend_ssl"]
     if tcp_proxy["backend_ssl"].downcase == "verify"
       backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -22,6 +22,16 @@
     end
   end
 
+  if !p("ha_proxy.client_cert", nil)
+    if p("ha_proxy.client_cert_ignore_err", false)
+      abort "Conflicting configuration: must provide client_cert to use client_cert_ignore_err"
+    end
+
+    if p("ha_proxy.client_revocation_list", false)
+      abort "Conflicting configuration: must provide client_cert to use client_revocation_list"
+    end
+  end
+
 require "digest"
 # Ruby Variables to make the template more readable
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -105,7 +105,7 @@ end
 # IPv4 and IPv6 binding (v4v6) Option {{{
 v4v6 = ""
 if_p("ha_proxy.v4v6") do
-  if p("ha_proxy.binding_ip") == "::" then
+  if p("ha_proxy.binding_ip") == "::"
     v4v6 = "v4v6"
   end
 end
@@ -113,7 +113,7 @@ end
 
 # ALPN Option {{{
 alpn_config = ""
-if p("ha_proxy.enable_http2") then
+if p("ha_proxy.enable_http2")
   alpn_config = "alpn h2,http/1.1 "
 end
 # }}}
@@ -125,8 +125,8 @@ global
   <%- if properties.ha_proxy.global_config -%>
     <%= p("ha_proxy.global_config") %>
   <%- end -%>
-  <%- if p("ha_proxy.nbproc") > 1 then -%>
-    <%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr" then
+  <%- if p("ha_proxy.nbproc") > 1  -%>
+    <%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr"
 			raise("ha_proxy.syslog_server cannot be stdout or stderr when ha_proxy.nbproc > 1. Try /dev/log instead")
 		end -%>
     nbproc <%= p("ha_proxy.nbproc") %>
@@ -241,7 +241,7 @@ frontend http-in
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
   <%- end -%>
-  <%- if p("ha_proxy.block_all") then -%>
+  <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
     capture request header Host len 256
@@ -313,17 +313,17 @@ frontend https-in
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
   <%- end -%>
-  <%- if p("ha_proxy.block_all") then -%>
+  <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
-  <%- if xfcc_forward_only then -%>
-    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled then %> if ! { ssl_c_used }<% end %>
-  <%- elsif xfcc_sanitize_set then -%>
+  <%- if xfcc_forward_only  -%>
+    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled  %> if ! { ssl_c_used }<% end %>
+  <%- elsif xfcc_sanitize_set  -%>
     http-request del-header X-Forwarded-Client-Cert
-    <%- if mutual_tls_enabled then -%>
+    <%- if mutual_tls_enabled  -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
     <%- end -%>
-  <%- elsif xfcc_forward_only_if_route_service then -%>
+  <%- elsif xfcc_forward_only_if_route_service  -%>
     acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
     http-request del-header X-Forwarded-Client-Cert if !route_service_request
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
@@ -393,14 +393,14 @@ frontend wss-in
     acl blacklist src -f /var/vcap/jobs/haproxy/config/blacklist_cidrs.txt
     tcp-request content reject if blacklist
   <%- end -%>
-  <%- if p("ha_proxy.block_all") then -%>
+  <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
-  <%- if xfcc_forward_only then -%>
-    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled then %> if ! { ssl_c_used }<% end %>
-  <%- elsif xfcc_sanitize_set then -%>
+  <%- if xfcc_forward_only  -%>
+    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled  %> if ! { ssl_c_used }<% end %>
+  <%- elsif xfcc_sanitize_set  -%>
     http-request del-header X-Forwarded-Client-Cert
-    <%- if mutual_tls_enabled then -%>
+    <%- if mutual_tls_enabled  -%>
     http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
     <%- end -%>
   <%- end -%>
@@ -472,7 +472,7 @@ backend http-routers
     backend_servers = backend.instances.map(&:address)
     backend_port = backend.p("port", p("ha_proxy.backend_port"))
 
-    if p("ha_proxy.backend_prefer_local_az") then
+    if p("ha_proxy.backend_prefer_local_az")
       backend_servers_local = backend.instances.select{ |n| n.az == spec.az }.map(&:address)
     end
   end.else_if_p("ha_proxy.backend_servers") do |servers|
@@ -488,23 +488,23 @@ backend http-routers
     backend_crt = "crt /var/vcap/jobs/haproxy/config/backend-crt.pem "
   end
   backend_ssl = ""
-  if p("ha_proxy.backend_ssl").downcase == "verify" then
+  if p("ha_proxy.backend_ssl").downcase == "verify"
     backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
     if_p("ha_proxy.backend_ssl_verifyhost") do | verify_hostname |
       backend_ssl += "verifyhost #{verify_hostname} "
     end
     backend_ssl += alpn_config
-  elsif p("ha_proxy.backend_ssl").downcase == "noverify" then
+  elsif p("ha_proxy.backend_ssl").downcase == "noverify"
     backend_ssl = "ssl verify none "
     backend_ssl += alpn_config
   end
 -%>
-  <%- if p("ha_proxy.backend_use_http_health") == true then -%>
+  <%- if p("ha_proxy.backend_use_http_health") == true  -%>
     option httpchk GET <%= p("ha_proxy.backend_http_health_uri") %>
     <%- health_check_options = "port " + p("ha_proxy.backend_http_health_port").to_s -%>
   <%- end -%>
   <% backend_servers.each_with_index do |ip, index| %>
-    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip) then -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port -%> <%= resolvers -%><%= backend_crt -%>check inter 1000 <%= health_check_options %> <%= backend_ssl %><%- if !backend_servers_local.empty? && !backend_servers_local.include?(ip)  -%> backup<%- end -%>
   <% end %>
 # }}}
 
@@ -527,20 +527,20 @@ backend http-routed-backend-<%= prefix_hash %>
     resolvers = "resolvers default "
   end
   backend_ssl = ""
-  if data["backend_ssl"] then
-    if data["backend_ssl"].downcase == "verify" then
+  if data["backend_ssl"]
+    if data["backend_ssl"].downcase == "verify"
       backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
-      if data["backend_verifyhost"] then
+      if data["backend_verifyhost"]
         backend_ssl += "verifyhost #{data["backend_verifyhost"]} "
       end
       backend_ssl += alpn_config
-    elsif data["backend_ssl"].downcase == "noverify" then
+    elsif data["backend_ssl"].downcase == "noverify"
       backend_ssl = "ssl verify none "
       backend_ssl += alpn_config
     end
   end
 -%>
-  <%- if data["backend_use_http_health"] == true then -%>
+  <%- if data["backend_use_http_health"] == true  -%>
     <%- data["backend_http_health_port"] ||= data["port"] -%>
     <%- data["backend_http_health_uri"] ||= "/health" -%>
     option httpchk GET <%= data["backend_http_health_uri"] %>
@@ -622,22 +622,22 @@ backend tcp-<%= tcp_proxy["name"] %>
     resolvers = "resolvers default "
   end
   backend_ssl = ""
-  if tcp_proxy["backend_ssl"] then
-    if tcp_proxy["backend_ssl"].downcase == "verify" then
+  if tcp_proxy["backend_ssl"]
+    if tcp_proxy["backend_ssl"].downcase == "verify"
       backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "
-      if tcp_proxy["backend_verifyhost"] then
+      if tcp_proxy["backend_verifyhost"]
         backend_ssl += "verifyhost #{tcp_proxy["backend_verifyhost"]} "
       end
-    elsif tcp_proxy["backend_ssl"].downcase == "noverify" then
+    elsif tcp_proxy["backend_ssl"].downcase == "noverify"
       backend_ssl = "ssl verify none "
     end
   end
 -%>
   <% tcp_proxy["backend_servers"].each_with_index do |ip, index| %>
-    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check port <%= backend_check_port -%> inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip) then -%> backup<%- end -%>
+    server node<%= index %> <%= ip %>:<%= backend_port %> <%= resolvers -%>check port <%= backend_check_port -%> inter 1000 <%= backend_ssl %><%- if tcp_proxy["backend_servers_local"] && !tcp_proxy["backend_servers_local"].empty? && !tcp_proxy["backend_servers_local"].include?(ip)  -%> backup<%- end -%>
   <% end %>
 
-  <%- if tcp_proxy["health_check_http"] then -%>
+  <%- if tcp_proxy["health_check_http"]  -%>
 listen health_check_http_tcp-<%= tcp_proxy["name"] %>
     bind :<%= tcp_proxy["health_check_http"] %>
     mode http

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -1,9 +1,30 @@
 <% if properties.ha_proxy.raw_config -%>
 <%= p("ha_proxy.raw_config") %>
-<% else -%>
-<% require "digest" -%>
-<%# Ruby Variables to make the template more readable -%>
-<%
+<%- else -%>
+<%-
+  # Error checking
+  if !p("ha_proxy.drain_enable", false) && p("ha_proxy.drain_frontend_grace_time") > 0
+    abort "Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time"
+  end
+
+  if !p("ha_proxy.hsts_enable", false)
+    if p("ha_proxy.hsts_include_subdomains")
+      abort "Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains"
+    end
+    if p("ha_proxy.hsts_preload")
+      abort "Conflicting configuration: hsts_enable must be true to enable hsts_preload"
+    end
+  end
+
+  if p("ha_proxy.backend_ssl", "").downcase != "verify"
+    if p("ha_proxy.backend_ssl_verifyhost", false)
+      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost"
+    end
+  end
+
+require "digest"
+# Ruby Variables to make the template more readable
+
 # Stats Binding Variables {{{
 stat = p("ha_proxy.stats_bind").split(':')
 stat_prefix = stat[0] + ":";
@@ -330,16 +351,7 @@ frontend https-in
   <%- end -%>
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
-  <%-
-    else
-      if p("ha_proxy.hsts_include_subdomains")
-        abort "Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains"
-      end
-      if p("ha_proxy.hsts_preload")
-        abort "Conflicting configuration: hsts_enable must be true to enable hsts_preload"
-      end
-    end
-  -%>
+  <%- end -%>
     capture request header Host len 256
     default_backend http-routers
   <%- if_p("ha_proxy.http_request_deny_conditions") do |conditions| -%>
@@ -497,12 +509,6 @@ backend http-routers
     backend_crt = "crt /var/vcap/jobs/haproxy/config/backend-crt.pem "
   end
   backend_ssl = ""
-
-  if (p("ha_proxy.backend_ssl") || "").downcase != "verify"
-    if_p("ha_proxy.backend_ssl_verifyhost") do |_|
-      abort "Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost"
-    end
-  end
 
   if p("ha_proxy.backend_ssl").downcase == "verify"
     backend_ssl = "ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem "

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -613,7 +613,7 @@ backend tcp-<%= tcp_proxy["name"] %>
   if tcp_proxy["backend_port"]
     backend_port = tcp_proxy["backend_port"]
   end
-  backend_check_port = tcp_proxy["backend_port"]
+  backend_check_port = backend_port
   if_p("ha_proxy.tcp_link_check_port") do
     backend_check_port = p("ha_proxy.tcp_link_check_port")
   end

--- a/jobs/haproxy/templates/reload.erb
+++ b/jobs/haproxy/templates/reload.erb
@@ -2,7 +2,7 @@
 
 set -e
 
-<%- if p("ha_proxy.reload_max_instances") then -%>
+<%- if p("ha_proxy.reload_max_instances") -%>
 max_instances=<%= p("ha_proxy.reload_max_instances") %>
 <%- else -%>
 max_instances=0

--- a/jobs/haproxy/templates/trusted_domain_cidrs.txt.erb
+++ b/jobs/haproxy/templates/trusted_domain_cidrs.txt.erb
@@ -10,7 +10,7 @@ end
 
 if_p("ha_proxy.trusted_domain_cidrs") do |cidrs|
   uncompressed = ''
-  if contains_ip_address?(cidrs) then
+  if contains_ip_address?(cidrs)
     cidrs.split(' ').each do |cidr|
       uncompressed << cidr << "\n"
     end

--- a/jobs/haproxy/templates/whitelist_cidrs.txt.erb
+++ b/jobs/haproxy/templates/whitelist_cidrs.txt.erb
@@ -6,7 +6,7 @@ require 'stringio'
 
 if_p("ha_proxy.cidr_whitelist") do |cidrs|
   uncompressed = ''
-  if cidrs.is_a?(Array) then
+  if cidrs.is_a?(Array)
     uncompressed << "\# detected cidrs provided as array in cleartext format\n"
     cidrs.each do |cidr|
       uncompressed << cidr << "\n"

--- a/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
@@ -129,8 +129,6 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
     end
   end
 
-  # FIXME: ha_proxy.backend_crt is not supported for routed http backends
-
   context 'when backend_ssl is verify' do
     let(:properties) do
       default_properties.deep_merge({

--- a/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_routed_spec.rb
@@ -105,8 +105,6 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
         })
       end
 
-      # FIXME: if backend_http_health_port is provided but backend_use_http_health is false, it should error
-
       it 'configures the correct check port on the servers' do
         expect(backend_images).to include('server node0 10.0.0.2:443 check inter 1000 port 9999')
         expect(backend_images).to include('server node1 10.0.0.3:443 check inter 1000 port 9999')
@@ -124,8 +122,6 @@ describe 'config/haproxy.config backend http-routed-backend-X' do
           }
         })
       end
-
-      # FIXME: if backend_http_health_uri is provided but backend_use_http_health is false, it should error
 
       it 'overrides the default health check uri' do
         expect(backend_images).to include('option httpchk GET /alive')

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -81,8 +81,6 @@ describe 'config/haproxy.config backend http-routers' do
         }
       end
 
-      # FIXME: if backend_http_health_uri is provided but backend_use_http_health is false, it should error
-
       it 'configures the healthcheck' do
         expect(backend_http_routers).to include('option httpchk GET 1.2.3.5/health')
       end
@@ -101,8 +99,6 @@ describe 'config/haproxy.config backend http-routers' do
           'backend_servers' => ['10.0.0.1', '10.0.0.2']
         }
       end
-
-      # FIXME: if backend_http_health_port is provided but backend_use_http_health is false, it should error
 
       it 'configures the healthcheck' do
         expect(backend_http_routers).to include('option httpchk GET /health')

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -160,11 +160,25 @@ describe 'config/haproxy.config backend http-routers' do
         }
       end
 
-      # FIXME: it should probably error if backend_ssl_verifyhost is provided but backend_ssl is not 'verify'
-
       it 'configures the server to use ssl: verify with verifyhost for the provided host name' do
         expect(backend_http_routers).to include('server node0 10.0.0.1:80 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
         expect(backend_http_routers).to include('server node1 10.0.0.2:80 check inter 1000  ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
+      end
+
+      context 'when ha_proxy.backend_ssl is not verify' do
+        let(:properties) do
+          {
+            'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+            'backend_ssl' => 'noverify',
+            'backend_ssl_verifyhost' => 'backend.com'
+          }
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            backend_http_routers
+          end.to raise_error /Conflicting configuration: backend_ssl must be 'verify' to use backend_ssl_verifyhost/
+        end
       end
     end
 

--- a/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_http_spec.rb
@@ -312,8 +312,6 @@ describe 'config/haproxy.config backend http-routers' do
         { 'backend_prefer_local_az' => true }
       end
 
-      # FIXME: if backend_prefer_local_az is true, but no http_backend link is provided then it should probably error
-
       it 'configures servers in other azs as backup servers' do
         expect(backend_http_routers).to include('server node0 backend.az1.internal:80 check inter 1000')
         expect(backend_http_routers).to include('server node1 backend.az2.internal:80 check inter 1000   backup')

--- a/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
@@ -198,11 +198,30 @@ describe 'config/haproxy.config custom TCP backends' do
         }
       end
 
-      # FIXME: it should probably error if backend_ssl_verifyhost is provided but backend_ssl is not 'verify'
-
       it 'configures the server to use ssl: verify with verifyhost for the provided host name' do
         expect(backend_tcp_redis).to include('server node0 10.0.0.1:6379 check port 6379 inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
         expect(backend_tcp_redis).to include('server node1 10.0.0.2:6379 check port 6379 inter 1000 ssl verify required ca-file /var/vcap/jobs/haproxy/config/backend-ca-certs.pem verifyhost backend.com')
+      end
+
+      context 'when ha_proxy.backend_ssl is not verify' do
+        let(:properties) do
+          {
+            'tcp_link_port' => 5432,
+            'tcp' => [{
+              'name' => 'redis',
+              'port' => 6379,
+              'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+              'backend_ssl' => 'noverify',
+              'backend_verifyhost' => 'backend.com'
+            }]
+          }
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            backend_tcp_redis
+          end.to raise_error /Conflicting configuration: backend_ssl must be 'verify' to use backend_verifyhost in tcp backend configuration/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
@@ -31,13 +31,11 @@ describe 'config/haproxy.config custom TCP backends' do
       'tcp_link_port' => 5432,
       'tcp' => [{
         'name' => 'redis',
-        'port' => 6380,
-        'backend_port' => 6379,
+        'port' => 6379,
         'backend_servers' => ['10.0.0.1', '10.0.0.2']
       }, {
         'name' => 'mysql',
-        'port' => 3307,
-        'backend_port' => 3306,
+        'port' => 3306,
         'backend_servers' => ['11.0.0.1', '11.0.0.2']
       }]
     }
@@ -51,20 +49,47 @@ describe 'config/haproxy.config custom TCP backends' do
     expect(backend_tcp_postgres_via_link).to include('mode tcp')
   end
 
+  context 'when backend_port is provided' do
+    let(:properties) do
+      {
+        'tcp_link_port' => 5432,
+        'tcp' => [{
+          'name' => 'redis',
+          'port' => 6379,
+          'backend_port' => 6380,
+          'backend_servers' => ['10.0.0.1', '10.0.0.2'],
+          'balance' => 'leastconn'
+        }, {
+          'name' => 'mysql',
+          'port' => 3306,
+          'backend_port' => 3307,
+          'backend_servers' => ['11.0.0.1', '11.0.0.2'],
+          'balance' => 'leastconn'
+        }]
+      }
+    end
+
+    it 'configures the backend servers with the correct backend port' do
+      expect(backend_tcp_redis).to include('server node0 10.0.0.1:6380 check port 6380 inter 1000')
+      expect(backend_tcp_redis).to include('server node1 10.0.0.2:6380 check port 6380 inter 1000')
+
+      expect(backend_tcp_mysql).to include('server node0 11.0.0.1:3307 check port 3307 inter 1000')
+      expect(backend_tcp_mysql).to include('server node1 11.0.0.2:3307 check port 3307 inter 1000')
+    end
+  end
+
   context 'when balance is provided (not available via link)' do
     let(:properties) do
       {
         'tcp_link_port' => 5432,
         'tcp' => [{
           'name' => 'redis',
-          'port' => 6380,
-          'backend_port' => 6379,
+          'port' => 6379,
           'backend_servers' => ['10.0.0.1', '10.0.0.2'],
           'balance' => 'leastconn'
         }, {
           'name' => 'mysql',
-          'port' => 3307,
-          'backend_port' => 3306,
+          'port' => 3306,
           'backend_servers' => ['11.0.0.1', '11.0.0.2'],
           'balance' => 'leastconn'
         }]
@@ -76,8 +101,6 @@ describe 'config/haproxy.config custom TCP backends' do
       expect(backend_tcp_mysql).to include('balance leastconn')
     end
   end
-
-  # FIXME: when backend_port is not provided, the check port is empty creating an invalid config
 
   # FIXME: tcp backend ignores ha_proxy.backend_prefer_local_az
 
@@ -98,8 +121,7 @@ describe 'config/haproxy.config custom TCP backends' do
         'tcp_link_port' => 5432,
         'tcp' => [{
           'name' => 'redis',
-          'port' => 6380,
-          'backend_port' => 6379,
+          'port' => 6379,
           'backend_servers' => ['10.0.0.1', '10.0.0.2'],
           'backend_servers_local' => ['10.0.0.1']
         }]
@@ -150,8 +172,7 @@ describe 'config/haproxy.config custom TCP backends' do
         'tcp_link_port' => 5432,
         'tcp' => [{
           'name' => 'redis',
-          'port' => 6380,
-          'backend_port' => 6379,
+          'port' => 6379,
           'backend_servers' => ['10.0.0.1', '10.0.0.2'],
           'backend_ssl' => 'verify'
         }]
@@ -169,8 +190,7 @@ describe 'config/haproxy.config custom TCP backends' do
           'tcp_link_port' => 5432,
           'tcp' => [{
             'name' => 'redis',
-            'port' => 6380,
-            'backend_port' => 6379,
+            'port' => 6379,
             'backend_servers' => ['10.0.0.1', '10.0.0.2'],
             'backend_ssl' => 'verify',
             'backend_verifyhost' => 'backend.com'
@@ -193,8 +213,7 @@ describe 'config/haproxy.config custom TCP backends' do
         'tcp_link_port' => 5432,
         'tcp' => [{
           'name' => 'redis',
-          'port' => 6380,
-          'backend_port' => 6379,
+          'port' => 6379,
           'backend_servers' => ['10.0.0.1', '10.0.0.2'],
           'backend_ssl' => 'noverify'
         }]

--- a/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/backend_tcp_spec.rb
@@ -102,8 +102,6 @@ describe 'config/haproxy.config custom TCP backends' do
     end
   end
 
-  # FIXME: tcp backend ignores ha_proxy.backend_prefer_local_az
-
   it 'configures the backend servers' do
     expect(backend_tcp_redis).to include('server node0 10.0.0.1:6379 check port 6379 inter 1000')
     expect(backend_tcp_redis).to include('server node1 10.0.0.2:6379 check port 6379 inter 1000')

--- a/spec/haproxy/templates/haproxy_config/frontend_cf_tcp_routing_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_cf_tcp_routing_spec.rb
@@ -81,6 +81,21 @@ describe 'config/haproxy.config frontend cf_tcp_routing' do
       it 'overrides the grace period' do
         expect(frontend_cf_tcp_routing).to include('grace 12000')
       end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          {
+            'drain_enable' => false,
+            'drain_frontend_grace_time' => 12
+          }
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_cf_tcp_routing
+          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
+        end
+      end
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_http_spec.rb
@@ -26,10 +26,20 @@ describe 'config/haproxy.config HTTP frontend' do
         { 'drain_enable' => true, 'drain_frontend_grace_time' => 12 }
       end
 
-      # FIXME: if drain_frontend_grace_time is provided but drain_enable is false then it should error
-
       it 'overrides the grace period' do
         expect(frontend_http).to include('grace 12000')
+      end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          { 'drain_enable' => false, 'drain_frontend_grace_time' => 12 }
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_http
+          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -32,10 +32,20 @@ describe 'config/haproxy.config HTTPS frontend' do
         default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
       end
 
-      # FIXME: if drain_frontend_grace_time is provided but drain_enable is false then it should error
-
       it 'overrides the grace period' do
         expect(frontend_https).to include('grace 12000')
+      end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_https
+          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -197,10 +197,20 @@ describe 'config/haproxy.config HTTPS frontend' do
         default_properties.merge({ 'hsts_enable' => true, 'hsts_include_subdomains' => true })
       end
 
-      # FIXME: hsts_include_subdomains is true but hsts_enable is false, then it should error
-
       it 'sets the includeSubDomains flag' do
         expect(frontend_https).to include('http-response set-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;')
+      end
+
+      context 'when ha_proxy.hsts_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'hsts_enable' => false, 'hsts_include_subdomains' => true })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_https
+          end.to raise_error /Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains/
+        end
       end
     end
 
@@ -209,10 +219,20 @@ describe 'config/haproxy.config HTTPS frontend' do
         default_properties.merge({ 'hsts_enable' => true, 'hsts_preload' => true })
       end
 
-      # FIXME: hsts_preload is true but hsts_enable is false, then it should error
-
       it 'sets the preload flag' do
         expect(frontend_https).to include('http-response set-header Strict-Transport-Security max-age=31536000;\ preload;')
+      end
+
+      context 'when ha_proxy.hsts_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'hsts_enable' => false, 'hsts_preload' => true })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_https
+          end.to raise_error /Conflicting configuration: hsts_enable must be true to enable hsts_preload/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_tcp_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_tcp_spec.rb
@@ -65,12 +65,22 @@ describe 'config/haproxy.config custom TCP frontends' do
         default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
       end
 
-      # FIXME: if drain_frontend_grace_time is provided but drain_enable is false then it should error
-
       it 'overrides the grace period' do
         expect(frontend_tcp_redis).to include('grace 12000')
         expect(frontend_tcp_mysql).to include('grace 12000')
         expect(frontend_tcp_postgres_via_link).to include('grace 12000')
+      end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_tcp_redis
+          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -91,7 +91,7 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
 
   context 'when mutual tls is enabled' do
     let(:properties) do
-      default_properties.merge({ 'client_cert' => 'client_cert contents' })
+      default_properties.merge({ 'client_cert' => true })
     end
 
     it 'configures ssl to use the client ca' do
@@ -100,25 +100,45 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
 
     context 'when ha_proxy.client_cert_ignore_err is true' do
       let(:properties) do
-        default_properties.merge({ 'client_cert' => 'client_cert contents', 'client_cert_ignore_err' => true })
+        default_properties.merge({ 'client_cert' => true, 'client_cert_ignore_err' => true })
       end
-
-      # FIXME: if client_cert_ignore_err is true but client_cert is not provided, then it should error
 
       it 'adds the crt-ignore-err flag' do
         expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crt-ignore-err true')
+      end
+
+      context 'when client_cert is not enabled' do
+        let(:properties) do
+          default_properties.merge({ 'client_cert_ignore_err' => true })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_wss
+          end.to raise_error /Conflicting configuration: must enable client_cert to use client_cert_ignore_err/
+        end
       end
     end
 
     context 'when ha_proxy.client_revocation_list is provided' do
       let(:properties) do
-        default_properties.merge({ 'client_cert' => 'client_cert contents', 'client_revocation_list' => 'client_revocation_list contents' })
+        default_properties.merge({ 'client_cert' => true, 'client_revocation_list' => 'client_revocation_list contents' })
       end
-
-      # FIXME: if client_revocation_list is provided but client_cert is not provided, then it should error
 
       it 'references the crl list' do
         expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem')
+      end
+
+      context 'when client_cert is not enabled' do
+        let(:properties) do
+          default_properties.merge({ 'client_revocation_list' => 'client_revocation_list contents' })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_wss
+          end.to raise_error /Conflicting configuration: must enable client_cert to use client_revocation_list/
+        end
       end
     end
   end
@@ -142,7 +162,7 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       context 'when mutual TLS is enabled' do
         let(:properties) do
           default_properties.merge({
-            'client_cert' => 'client_cert contents',
+            'client_cert' => true,
             'forwarded_client_cert' => 'forward_only'
           })
         end
@@ -165,7 +185,7 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       context 'when mutual TLS is enabled' do
         let(:properties) do
           default_properties.merge({
-            'client_cert' => 'client_cert contents',
+            'client_cert' => true,
             'forwarded_client_cert' => 'sanitize_set'
           })
         end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -37,10 +37,20 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
         default_properties.merge({ 'drain_enable' => true, 'drain_frontend_grace_time' => 12 })
       end
 
-      # FIXME: if drain_frontend_grace_time is provided but drain_enable is false then it should error
-
       it 'overrides the grace period' do
         expect(frontend_wss).to include('grace 12000')
+      end
+
+      context 'when ha_proxy.drain_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'drain_enable' => false, 'drain_frontend_grace_time' => 12 })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_wss
+          end.to raise_error /Conflicting configuration: drain_enable must be true to use drain_frontend_grace_time/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -11,9 +11,6 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
 
   let(:frontend_wss) { haproxy_conf['frontend wss-in'] }
 
-  # FIXME: wss frontend should error if neither ssl_pem or crt_list are
-  # Currently the config is invalid without one of these options
-
   let(:default_properties) do
     {
       'enable_4443' => true,
@@ -398,6 +395,18 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
 
     it 'removes the wss frontend' do
       expect(haproxy_conf).not_to have_key('frontend wss-in')
+    end
+  end
+
+  context('when no valid SSL config is provided') do
+    let(:properties) do
+      { 'enable_4443' => true }
+    end
+
+    it 'aborts with a meaningful error message' do
+      expect do
+        frontend_wss
+      end.to raise_error /Conflicting configuration: if enable_4443 is true, you must provide a valid SSL config via ssl_pem or crt_list/
     end
   end
 end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -192,7 +192,17 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
         default_properties.merge({ 'hsts_enable' => true, 'hsts_include_subdomains' => true })
       end
 
-      # FIXME: hsts_include_subdomains is true but hsts_enable is false, then it should error
+      context 'when ha_proxy.hsts_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'hsts_enable' => false, 'hsts_include_subdomains' => true })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_wss
+          end.to raise_error /Conflicting configuration: hsts_enable must be true to use hsts_include_subdomains/
+        end
+      end
 
       it 'sets the includeSubDomains flag' do
         expect(frontend_wss).to include('http-response set-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;')
@@ -204,10 +214,20 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
         default_properties.merge({ 'hsts_enable' => true, 'hsts_preload' => true })
       end
 
-      # FIXME: hsts_preload is true but hsts_enable is false, then it should error
-
       it 'sets the preload flag' do
         expect(frontend_wss).to include('http-response set-header Strict-Transport-Security max-age=31536000;\ preload;')
+      end
+
+      context 'when ha_proxy.hsts_enable is false' do
+        let(:properties) do
+          default_properties.merge({ 'hsts_enable' => false, 'hsts_preload' => true })
+        end
+
+        it 'aborts with a meaningful error message' do
+          expect do
+            frontend_wss
+          end.to raise_error /Conflicting configuration: hsts_enable must be true to enable hsts_preload/
+        end
       end
     end
   end

--- a/spec/haproxy/templates/trusted_domain_cidrs.txt_spec.rb
+++ b/spec/haproxy/templates/trusted_domain_cidrs.txt_spec.rb
@@ -25,7 +25,6 @@ describe 'config/trusted_domain_cidrs.txt' do
       end
     end
 
-    # FIXME: this feature does not seem to be documented
     context 'when a newline-separated, gzipped, base64-encoded list of cidrs is provided' do
       it 'has the correct contents' do
         expect(template.render({


### PR DESCRIPTION
~**Requires #207 is merged first**~

These are a series of small changes aimed at:
1. Improving specs where there may be some confusion
2. Preventing the user from accidentally configuring properties in an inconsistent way

Changes:
* Document fact that `trusted_domain_cidrs` can be b64-encoded gzipped cidr list file
* Fix bug where TCP check port is invalid if `port` is provided but `backend_port` is not
* Removed unnecessary `then` keywords in erb templates (`then` is only needed for one-liners)
* If SSL host verification is enabled, it will error if SSL verification is not enabled
* If HSTS is disabled, it will error if HSTS preload or HSTS subdomains are set
* If `drain_frontend_grace_time` is non-zero it will error if `drain_enable` is not true
* Update `tcp` spec to document previously hidden property `backend_servers_local`
* Update `backend_prefer_local_az` spec to clarify that it only affects backend servers are provided via `http_backend` links (NOTE: this is the existing behaviour but we might want to change this in the future)
* If `client_cert` is not provided but `client_revocation_list` or `client_cert_ignore_err` are, then it will error
* If `enable_4443` (HTTPs websockets) is true, then a valid SSL config must be provided
* Update spec to clarify which types of backend `backend_crt` will be used with 