### PR TITLE
Add properties to enable HAProxy master CLI

### DIFF
--- a/acceptance-tests/master_cli_test.go
+++ b/acceptance-tests/master_cli_test.go
@@ -1,0 +1,71 @@
+package acceptance_tests
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Master CLI", func() {
+	It("Works when enabled", func() {
+		opsfileMasterCLI := `---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/master_cli_enable?
+  value: true
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/master_cli_bind?
+  value: '0.0.0.0:9001'
+`
+		haproxyInfo, _ := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    12000,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        defaultDeploymentName,
+		}, []string{opsfileMasterCLI}, map[string]interface{}{}, true)
+
+		By("The master CLI 'show proc' command works")
+		output, err := haproxyCLICommand("show proc", fmt.Sprintf("%s:9001", haproxyInfo.PublicIP))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Example expected output
+		// #<PID>          <type>          <relative PID>  <reloads>       <uptime>        <version>
+		// 15              master          0               0               0d00h11m09s     2.2.14-a07ac36
+		// # workers
+		// 17              worker          1               0               0d00h11m09s     2.2.14-a07ac36
+		Expect(string(output)).To(MatchRegexp("[0-9]+[\\s]+master"))
+		Expect(string(output)).To(MatchRegexp("[0-9]+[\\s]+worker"))
+	})
+})
+
+func haproxyCLICommand(command string, addr string) (string, error) {
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	// HAProxy master CLI does not close connection after writing response,
+	// so we will close after one second
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		return "", err
+	}
+
+	if _, err := conn.Write([]byte(fmt.Sprintf("%s\n", command))); err != nil {
+		return "", err
+	}
+
+	var buffer bytes.Buffer
+	if _, err := buffer.ReadFrom(conn); err != nil && !isTimeoutError(err) {
+		return "", err
+	}
+
+	return buffer.String(), nil
+}
+
+func isTimeoutError(err error) bool {
+	e, ok := err.(net.Error)
+	return ok && e.Timeout()
+}

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -261,6 +261,13 @@ properties:
     description: "Trusted ip range that can access the stats UI"
     default: 0.0.0.0/32
 
+  ha_proxy.master_cli_enable:
+    description: "If true, enables the master CLI which can be used to manage HAProxy"
+    default: false
+  ha_proxy.master_cli_bind:
+    description: "IP and port or UNIX socket to bind master CLI to"
+    default: "127.0.0.1:9001"
+
   ha_proxy.backend_servers:
     description: "Array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"
     default: []

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -3,11 +3,9 @@
 
 set -e
 
-PATH=/var/vcap/packages/haproxy/bin:${PATH}
-DAEMON=/var/vcap/packages/haproxy/bin/haproxy
+export PATH=$PATH:/var/vcap/packages/haproxy/bin:/var/vcap/packages/ttar/bin
 CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
-export PATH=$PATH:/var/vcap/packages/ttar/bin
 
 cleanup_daemon() {
   if [ -f ${PID_FILE} ]; then
@@ -84,13 +82,28 @@ trap shutdown QUIT INT TERM EXIT
 # enable hitless reloads
 trap reload_daemon USR2
 
+<%-
+  flags=[]
+
+  # Enable background mode only if syslog is not configured to output to stdout/stderr
+  run_in_foreground = p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr"
+
+  if run_in_foreground
+    flags += ['-V', '-db']
+  else
+    flags += ['-D']
+  end
+
+  if p('ha_proxy.master_cli_enable')
+    flags += ['-S', p('ha_proxy.master_cli_bind')]
+  end
+-%>
+
 # Start up
 echo "$(date): Starting HAProxy"
-<%- if p('ha_proxy.syslog_server') == "stdout" || p('ha_proxy.syslog_server') == "stderr" -%>
-"${DAEMON}" -f "${CONFIG}" -W -p ${PID_FILE} -V -db
-<%- else -%>
-"${DAEMON}" -f "${CONFIG}" -W -D -p ${PID_FILE}
+haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %>
 
+<%- if !run_in_foreground -%>
 # Since HAProxy requires Daemonized mode for its `nbproc` multi-process feature
 # to work properly, and BPM requires the process to stay running, sleep infinitely here
 sleep infinity


### PR DESCRIPTION
Adds two new properties:
`master_cli_enable` (default `false`)
`master_cli_bind` (default `127.0.0.1:9001`)
With documentation in `spec` and an acceptance test

Master CLI allows managing HAProxy https://cbonte.github.io/haproxy-dconv/2.4/management.html#9.4