### PR TITLE
Add option for disabling domain fronting

### DIFF
--- a/acceptance-tests/domain_fronting_test.go
+++ b/acceptance-tests/domain_fronting_test.go
@@ -1,0 +1,96 @@
+package acceptance_tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Domain fronting", func() {
+	opsfile := `---
+# Disable domain fronting
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/disable_domain_fronting?
+  value: true
+# Configure CA and cert chain
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
+  value:
+    snifilter:
+    - haproxy.internal
+    ssl_pem:
+      cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
+      private_key: ((https_frontend.private_key))
+# Declare certs
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend
+    type: certificate
+    options:
+      ca: https_frontend_ca
+      common_name: haproxy.internal
+      alternative_names: [haproxy.internal]
+`
+
+	var creds struct {
+		HTTPSFrontend struct {
+			Certificate string `yaml:"certificate"`
+			PrivateKey  string `yaml:"private_key"`
+			CA          string `yaml:"ca"`
+		} `yaml:"https_frontend"`
+	}
+
+	It("Disables domain fronting", func() {
+		haproxyBackendPort := 12000
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        defaultDeploymentName,
+		}, []string{opsfile}, map[string]interface{}{}, true)
+
+		err := varsStoreReader(&creds)
+		Expect(err).NotTo(HaveOccurred())
+
+		closeLocalServer, localPort := startDefaultTestServer()
+		defer closeLocalServer()
+
+		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		defer closeTunnel()
+
+		httpClient := buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{
+				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
+			},
+			[]tls.Certificate{},
+		)
+
+		By("Sending a request to HAProxy with a mismatched SNI and Host header it returns a 421")
+		req, err := http.NewRequest("GET", "https://haproxy.internal", nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Host = "spoof.internal"
+
+		resp, err := httpClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusMisdirectedRequest))
+
+		By("Sending a request to HAProxy without a spoofed Host header it returns a 200 as normal")
+		resp, err = httpClient.Get("https://haproxy.internal")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
+	})
+})

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -71,6 +71,13 @@ properties:
   ha_proxy.strict_sni:
     description: "Optional setting to decide whether the SSL/TLS negotiation is allowed only if the client provided an SNI which strict match a certificate. If set to true, the default certificate is not used"
     default: false
+  ha_proxy.disable_domain_fronting:
+    description: |
+      If set to true, it will prevent clients from setting a host header different from the SNI value. This is called domain fronting and is mostly used by CDNs.
+      If domain fronting is disabled, such requests will result in a 421 Misdirected Request error.
+      Example:
+        curl -H "Host: bob.com" https://alice.com    <-- This will result in a 421 Misdirected Request
+    default: false
   ha_proxy.ssl_pem:
     description: |
       Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'cert_chain' and 'private_key',

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -73,7 +73,7 @@ properties:
     default: false
   ha_proxy.disable_domain_fronting:
     description: |
-      If set to true, it will prevent clients from setting a host header different from the SNI value. This is called domain fronting and is mostly used by CDNs.
+      If set to true, it will prevent clients from setting a host header different from the SNI value for HTTPS and WSS (secured websockets) connections. This is called domain fronting and is mostly used by CDNs.
       If domain fronting is disabled, such requests will result in a 421 Misdirected Request error.
       Example:
         curl -H "Host: bob.com" https://alice.com    <-- This will result in a 421 Misdirected Request

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -433,6 +433,12 @@ frontend wss-in
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
+  <%- if p("ha_proxy.disable_domain_fronting")-%>
+    # Check whether the client is attempting domain fronting.
+    http-request set-var(txn.host) hdr(host)
+    acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    http-request deny deny_status 421 unless ssl_sni_http_host_match
+  <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -337,6 +337,12 @@ frontend https-in
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %> <%= alpn_config %>
+  <%- if p("ha_proxy.disable_domain_fronting")-%>
+    # Check whether the client is attempting domain fronting.
+    http-request set-var(txn.host) hdr(host)
+    acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    http-request deny deny_status 421 unless ssl_sni_http_host_match
+  <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
   <%- end -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -84,6 +84,18 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
   end
 
+  context 'when ha_proxy.disable_domain_fronting is true' do
+    let(:properties) do
+      default_properties.merge({ 'disable_domain_fronting' => true })
+    end
+
+    it 'disables domain fronting by checkig SNI against the Host header' do
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host)')
+      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+      expect(frontend_https).to include('http-request deny deny_status 421 unless ssl_sni_http_host_match')
+    end
+  end
+
   context 'when mutual tls is disabled' do
     let(:properties) do
       default_properties.merge({ 'client_cert' => false })

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -86,6 +86,18 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
   end
 
+  context 'when ha_proxy.disable_domain_fronting is true' do
+    let(:properties) do
+      default_properties.merge({ 'disable_domain_fronting' => true })
+    end
+
+    it 'disables domain fronting by checkig SNI against the Host header' do
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host)')
+      expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+      expect(frontend_wss).to include('http-request deny deny_status 421 unless ssl_sni_http_host_match')
+    end
+  end
+
   context 'when mutual tls is enabled' do
     let(:properties) do
       default_properties.merge({ 'client_cert' => true })


### PR DESCRIPTION
[Domain Fronting](https://en.wikipedia.org/wiki/Domain_fronting) allows clients to set a host name different from the SNI value when connecting to a HTTPS-protected host.
This allows CDNs to serve hundreds of pages under the same domain without having to provide a valid certificate for each of them.
For example, a client could make this call:
```
curl -H "cute-puppies.com" https://big-cdn.com
```
To fetch the website of cute-puppies.com from the CDN.

A second usage of domain fronting is avoiding censorship. Since the HTTP host header is part of the L7 which is encrypted, the censor can only see the SNI value which is not.
By passing a non-blocked SNI value to the served and a host header to blocked content, a client can bypass censorship effectively.

There is a catch, of course.

When using mTLS to connect to a site, the client has to provide a valid certificate for the domain she wants to connect to. However, with domain fronting, the client could pass a valid certificate for domain A but then instruct the proxy to redirect to domain B that also requires a certificate. However, in this case mTLS was already terminated by connecting to domain A at the proxy. Thus, the client certificate will be accepted and forwarded to domain B, without validation.

To prevent such attacks,  a new option `disable_domain_fronting ` is provided that lets the operator choose to prevent domain fronting if such use cases are to be served over the proxy.