### PR TITLE
All XFCC headers should respect ha_proxy.forwarded_client_cert property

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -330,17 +330,7 @@ properties:
       -----END PRIVATE KEY-----
   ha_proxy.client_cert:
     description: |
-      Enable haproxy mutual auth and offload mutual ssl client certificate to backend.
-      The following headers will be produced if the client connects using a client certificate:
-        - X-Forwarded-Client-Cert: Contains the client certificate in binary DER format (Base64 encoded).
-        - X-SSL-Client: Contains the number 1 if the request was made using a client certificate, 0 otherwise. For easy checks on the backend.
-        - X-SSL-Client-Session-ID: The SSL session ID of the client connection. Useful for debugging purposes.
-        - X-SSL-Client-Verify: Contains the number 0 if the client certificate verification was successful. Otherwise it contains the appropriate OpenSSL return code (see https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in#L206)
-        - X-SSL-Client-Subject-DN: Contains the subject distinguished name of the client certificate.
-        - X-SSL-Client-Subject-CN: Contains the subject common name of the client certificate.
-        - X-SSL-Client-Issuer-DN: Contains the issuer distinguished name of the client certificate.
-        - X-SSL-Client-NotBefore: Contains the start date of the client certificate in YYMMDDhhmmss[Z] format.
-        - X-SSL-Client-NotAfter: Contains the expiration date of the client certificate in YYMMDDhhmmss[Z] format.
+      Enable haproxy mutual auth
     default: false
 
   ha_proxy.forwarded_client_cert:
@@ -349,20 +339,38 @@ properties:
       On http frontends the `always_forward_only` option is active by default and can't be changed.
       On https frontends your options are:
       - always_forward_only:
-          Least secure option. Always forward the XFCC header in the request, regardless of whether the client connection is mTLS.
+          Least secure option. Always forward the X-Forwarded-Client-Cert header in the request, regardless of whether the client connection is mTLS. The following headers will also be forwarded if they are present in the original request: X-SSL-Client, X-SSL-Client-Session-ID, X-SSL-Client-Verify, X-SSL-Client-Subject-DN, X-SSL-Client-Subject-CN, X-SSL-Client-Issuer-DN, X-SSL-Client-NotBefore, X-SSL-Client-NotAfter.
           Use this value when your load balancer is forwarding the client certificate and requests are not forwarded to HAProxy over mTLS.
           In the case where the connection between load balancer and HAProxy is mTLS, the client certificate received by HAProxy in the mTLS handshake will not be forwarded.
       - forward_only:
-          Secure version of `always_forward_only`. Forward the XFCC header received from the client only when the client connection is mTLS.
-          The client certificate received by HAProxy in the mTLS handshake will not be forwarded.
+          Secure version of `always_forward_only`. Forward the X-Forwarded-Client-Cert header received from the client only when the client connection is mTLS. The following headers will also be forwarded for mTLS connections if they are present in the original request: X-SSL-Client, X-SSL-Client-Session-ID, X-SSL-Client-Verify, X-SSL-Client-Subject-DN, X-SSL-Client-Subject-CN, X-SSL-Client-Issuer-DN, X-SSL-Client-NotBefore, X-SSL-Client-NotAfter.
+          If the client connection does not use mTLS, these X-Forwarded-Client-Cert and X-SSL-Client-* headers will be removed if they are present.
+          In the case where the connection between load balancer and HAProxy is mTLS, the client certificate received by HAProxy in the mTLS handshake will not be forwarded.
       - sanitize_set:
           Most secure option. Strip any instances of XFCC headers from the client request.
-          When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in this header.
-          Values will be base64 encoded PEM. Use this value when HAProxy is the first component to terminate TLS.
+          When the client connection is mTLS, the following headers will be overwritten in the request
+            - X-Forwarded-Client-Cert: Contains the client certificate in binary DER format (Base64 encoded). Backends should use this header to authenticate incoming requests.
+            - X-SSL-Client: Contains the number 1 if the request was made using a client certificate, 0 otherwise. For easy checks on the backend.
+            - X-SSL-Client-Session-ID: The SSL session ID of the client connection. Useful for debugging purposes.
+            - X-SSL-Client-Verify: Contains the number 0 if the client certificate verification was successful. Otherwise it contains the appropriate OpenSSL return code (see https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in#L206)
+            - X-SSL-Client-Subject-DN: Contains the subject distinguished name of the client certificate.
+            - X-SSL-Client-Subject-CN: Contains the subject common name of the client certificate.
+            - X-SSL-Client-Issuer-DN: Contains the issuer distinguished name of the client certificate.
+            - X-SSL-Client-NotBefore: Contains the start date of the client certificate in YYMMDDhhmmss[Z] format.
+            - X-SSL-Client-NotAfter: Contains the expiration date of the client certificate in YYMMDDhhmmss[Z] format.
       - forward_only_if_route_service:
           This option is useful to support Mutual TLS with CF Route Services.
-          When the client connection is mTLS, the client certificate received by HAProxy in the mTLS handshake will be forwarded in the XFCC header.
-          When the client connection is not mTLS, the XFCC header will be removed UNLESS there is an X-Cf-Proxy-Signature header.
+          When the client connection is not mTLS, the X-Forwarded-Client-Cert and X-SSL-Client-* headers will be removed UNLESS there is an X-Cf-Proxy-Signature header.
+          When the client connection is mTLS, the following headers will be overwritten in the request
+            - X-Forwarded-Client-Cert: Contains the client certificate in binary DER format (Base64 encoded). Backends should use this header to authenticate incoming requests.
+            - X-SSL-Client: Contains the number 1 if the request was made using a client certificate, 0 otherwise. For easy checks on the backend.
+            - X-SSL-Client-Session-ID: The SSL session ID of the client connection. Useful for debugging purposes.
+            - X-SSL-Client-Verify: Contains the number 0 if the client certificate verification was successful. Otherwise it contains the appropriate OpenSSL return code (see https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in#L206)
+            - X-SSL-Client-Subject-DN: Contains the subject distinguished name of the client certificate.
+            - X-SSL-Client-Subject-CN: Contains the subject common name of the client certificate.
+            - X-SSL-Client-Issuer-DN: Contains the issuer distinguished name of the client certificate.
+            - X-SSL-Client-NotBefore: Contains the start date of the client certificate in YYMMDDhhmmss[Z] format.
+            - X-SSL-Client-NotAfter: Contains the expiration date of the client certificate in YYMMDDhhmmss[Z] format.
           This option is only secure if Gorouter is deployed behind Haproxy to validate that X-Cf-Proxy-Signature is coming from a route service.
     default: sanitize_set
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -85,23 +85,29 @@ end
 tls_bind_options = "ssl #{tls_options}"
 # }}}
 # X-Forwarded-Client-Cert (XFCC) Option {{{
-xfcc_forward_only = false
-xfcc_sanitize_set = false
-xfcc_forward_only_if_route_service = false
+mtls_header_deletion_policy = :never
+write_mtls_headers = false
 
 forwarded_client_cert_option = p("ha_proxy.forwarded_client_cert").downcase
 case forwarded_client_cert_option
 when "always_forward_only"
   # NOP
 when "forward_only"
-  xfcc_forward_only = true
+  if mutual_tls_enabled
+    mtls_header_deletion_policy = :non_mtls_only
+  else
+    mtls_header_deletion_policy = :always
+  end
 when "sanitize_set"
-  xfcc_sanitize_set = true
+  mtls_header_deletion_policy = :always
+  write_mtls_headers = mutual_tls_enabled
 when "forward_only_if_route_service"
-  xfcc_forward_only_if_route_service = true
+  mtls_header_deletion_policy = :non_route_service_only
+  write_mtls_headers = mutual_tls_enabled
 else
   abort("Unknown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set', 'forward_only_if_route_service'")
 end
+
 # }}}
 # IPv4 and IPv6 binding (v4v6) Option {{{
 v4v6 = ""
@@ -357,28 +363,53 @@ frontend https-in
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
-  <%- if xfcc_forward_only  -%>
-    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled  %> if ! { ssl_c_used }<% end %>
-  <%- elsif xfcc_sanitize_set  -%>
+
+  <%- case mtls_header_deletion_policy -%>
+  <%- when :always -%>
     http-request del-header X-Forwarded-Client-Cert
-    <%- if mutual_tls_enabled  -%>
-    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
-    <%- end -%>
-  <%- elsif xfcc_forward_only_if_route_service  -%>
+    http-request del-header X-SSL-Client
+    http-request del-header X-SSL-Client-Session-ID
+    http-request del-header X-SSL-Client-Verify
+    http-request del-header X-SSL-Client-Subject-DN
+    http-request del-header X-SSL-Client-Subject-CN
+    http-request del-header X-SSL-Client-Issuer-DN
+    http-request del-header X-SSL-Client-NotBefore
+    http-request del-header X-SSL-Client-NotAfter
+  <%- when :non_mtls_only -%>
+    http-request del-header X-Forwarded-Client-Cert if ! { ssl_c_used }
+    http-request del-header X-SSL-Client            if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Session-ID if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Verify     if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Subject-DN if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Subject-CN if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Issuer-DN  if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-NotBefore  if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-NotAfter   if ! { ssl_c_used }
+  <%- when :non_route_service_only -%>
     acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
     http-request del-header X-Forwarded-Client-Cert if !route_service_request
-    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
+    http-request del-header X-SSL-Client            if !route_service_request
+    http-request del-header X-SSL-Client-Session-ID if !route_service_request
+    http-request del-header X-SSL-Client-Verify     if !route_service_request
+    http-request del-header X-SSL-Client-Subject-DN if !route_service_request
+    http-request del-header X-SSL-Client-Subject-CN if !route_service_request
+    http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request
+    http-request del-header X-SSL-Client-NotBefore  if !route_service_request
+    http-request del-header X-SSL-Client-NotAfter   if !route_service_request
   <%- end -%>
-  <%- if mutual_tls_enabled then -%>
-    http-request set-header X-SSL-Client              %[ssl_c_used]            if { ssl_c_used }
-    http-request set-header X-SSL-Client-Session-ID   %[ssl_fc_session_id,hex] if { ssl_c_used }
-    http-request set-header X-SSL-Client-Verify       %[ssl_c_verify]          if { ssl_c_used }
-    http-request set-header X-SSL-Client-Subject-DN   %{+Q}[ssl_c_s_dn]        if { ssl_c_used }
-    http-request set-header X-SSL-Client-Subject-CN   %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }
-    http-request set-header X-SSL-Client-Issuer-DN    %{+Q}[ssl_c_i_dn]        if { ssl_c_used }
-    http-request set-header X-SSL-Client-NotBefore    %{+Q}[ssl_c_notbefore]   if { ssl_c_used }
-    http-request set-header X-SSL-Client-NotAfter     %{+Q}[ssl_c_notafter]    if { ssl_c_used }
+
+  <%- if write_mtls_headers -%>
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }
+    http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }
+    http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }
+    http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }
+    http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }
+    http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }
+    http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }
+    http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }
+    http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }
   <%- end -%>
+
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
   <%- end -%>
@@ -453,14 +484,53 @@ frontend wss-in
   <%- if p("ha_proxy.block_all")  -%>
     tcp-request content reject
   <%- end -%>
-  <%- if xfcc_forward_only  -%>
-    http-request del-header X-Forwarded-Client-Cert<% if mutual_tls_enabled  %> if ! { ssl_c_used }<% end %>
-  <%- elsif xfcc_sanitize_set  -%>
+
+  <%- case mtls_header_deletion_policy -%>
+  <%- when :always -%>
     http-request del-header X-Forwarded-Client-Cert
-    <%- if mutual_tls_enabled  -%>
-    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }
-    <%- end -%>
+    http-request del-header X-SSL-Client
+    http-request del-header X-SSL-Client-Session-ID
+    http-request del-header X-SSL-Client-Verify
+    http-request del-header X-SSL-Client-Subject-DN
+    http-request del-header X-SSL-Client-Subject-CN
+    http-request del-header X-SSL-Client-Issuer-DN
+    http-request del-header X-SSL-Client-NotBefore
+    http-request del-header X-SSL-Client-NotAfter
+  <%- when :non_mtls_only -%>
+    http-request del-header X-Forwarded-Client-Cert if ! { ssl_c_used }
+    http-request del-header X-SSL-Client            if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Session-ID if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Verify     if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Subject-DN if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Subject-CN if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-Issuer-DN  if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-NotBefore  if ! { ssl_c_used }
+    http-request del-header X-SSL-Client-NotAfter   if ! { ssl_c_used }
+  <%- when :non_route_service_only -%>
+    acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
+    http-request del-header X-Forwarded-Client-Cert if !route_service_request
+    http-request del-header X-SSL-Client            if !route_service_request
+    http-request del-header X-SSL-Client-Session-ID if !route_service_request
+    http-request del-header X-SSL-Client-Verify     if !route_service_request
+    http-request del-header X-SSL-Client-Subject-DN if !route_service_request
+    http-request del-header X-SSL-Client-Subject-CN if !route_service_request
+    http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request
+    http-request del-header X-SSL-Client-NotBefore  if !route_service_request
+    http-request del-header X-SSL-Client-NotAfter   if !route_service_request
   <%- end -%>
+
+  <%- if write_mtls_headers -%>
+    http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }
+    http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }
+    http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }
+    http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }
+    http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }
+    http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }
+    http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }
+    http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }
+    http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }
+  <%- end -%>
+
   <%- if p("ha_proxy.hsts_enable") -%>
     http-response set-header Strict-Transport-Security max-age=<%= p("ha_proxy.hsts_max_age").to_i %>;<% if p("ha_proxy.hsts_include_subdomains") %>\ includeSubDomains;<% end %><% if p("ha_proxy.hsts_preload") %>\ preload;<% end %>
   <%- end -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -101,32 +101,15 @@ describe 'config/haproxy.config HTTPS frontend' do
       default_properties.merge({ 'client_cert' => false })
     end
 
-    it 'does not add additional mTLS headers' do
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client              %[ssl_c_used]            if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-Session-ID   %[ssl_fc_session_id,hex] if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-Verify       %[ssl_c_verify]          if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-Subject-DN   %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-Subject-CN   %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-Issuer-DN    %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-NotBefore    %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
-      expect(frontend_https).not_to include('http-request set-header X-SSL-Client-NotAfter     %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
+    it 'does not add mTLS headers' do
+      expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+      expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
     end
   end
 
   context 'when mutual tls is enabled' do
     let(:properties) do
       default_properties.merge({ 'client_cert' => true })
-    end
-
-    it 'adds additional mTLS headers' do
-      expect(frontend_https).to include('http-request set-header X-SSL-Client              %[ssl_c_used]            if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-Session-ID   %[ssl_fc_session_id,hex] if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-Verify       %[ssl_c_verify]          if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-DN   %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-CN   %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-Issuer-DN    %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-NotBefore    %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
-      expect(frontend_https).to include('http-request set-header X-SSL-Client-NotAfter     %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
     end
 
     it 'configures ssl to use the client ca' do
@@ -178,68 +161,177 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
   end
 
-  context 'when ha_proxy.forwarded_client_cert is always_forward_only (the default)' do
-    it 'deletes the X-Forwarded-Client-Cert header by default' do
-      expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
-    end
-  end
-
-  context 'when ha_proxy.forwarded_client_cert is forward_only' do
-    let(:properties) do
-      default_properties.merge({ 'forwarded_client_cert' => 'forward_only' })
-    end
-
-    it 'deletes the X-Forwarded-Client-Cert header' do
-      expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
-    end
-
-    context 'when mutual TLS is enabled' do
+  describe 'ha_proxy.forwarded_client_cert' do
+    context 'when ha_proxy.forwarded_client_cert is always_forward_only' do
       let(:properties) do
-        default_properties.merge({
-          'client_cert' => true,
-          'forwarded_client_cert' => 'forward_only'
-        })
+        default_properties.merge({ 'forwarded_client_cert' => 'always_forward_only' })
       end
 
-      it 'only deletes the X-Forwarded-Client-Cert header when mTLS is not used' do
-        expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert if ! { ssl_c_used }')
+      it 'does not delete mTLS headers' do
+        expect(frontend_https).not_to include(/http-request del-header X-Forwarded-Client-Cert/)
+        expect(frontend_https).not_to include(/http-request del-header X-SSL-Client/)
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+        expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
       end
     end
-  end
 
-  context 'when ha_proxy.forwarded_client_cert is sanitize_set' do
-    let(:properties) do
-      default_properties.merge({ 'forwarded_client_cert' => 'sanitize_set' })
-    end
-
-    it 'deletes the X-Forwarded-Client-Cert header' do
-      expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
-    end
-
-    context 'when mutual TLS is enabled' do
+    context 'when ha_proxy.forwarded_client_cert is forward_only' do
       let(:properties) do
-        default_properties.merge({
-          'client_cert' => true,
-          'forwarded_client_cert' => 'sanitize_set'
-        })
+        default_properties.merge({ 'forwarded_client_cert' => 'forward_only' })
       end
 
-      it 'sets X-Forwarded-Client-Cert to the client cert for mTLS connections ' do
+      it 'deletes mTLS headers' do
         expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
-        expect(frontend_https).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+        expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
+      end
+
+      context 'when mutual TLS is enabled' do
+        let(:properties) do
+          default_properties.merge({
+            'client_cert' => true,
+            'forwarded_client_cert' => 'forward_only'
+          })
+        end
+
+        it 'deletes mTLS headers when mTLS is not used' do
+          expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client            if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify     if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN  if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore  if ! { ssl_c_used }')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter   if ! { ssl_c_used }')
+        end
+
+        it 'does not add mTLS headers' do
+          expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+          expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
+        end
       end
     end
-  end
 
-  context 'when ha_proxy.forwarded_client_cert is forward_only_if_route_service' do
-    let(:properties) do
-      default_properties.merge({ 'forwarded_client_cert' => 'forward_only_if_route_service' })
+    context 'when ha_proxy.forwarded_client_cert is sanitize_set (the default)' do
+      it 'always deletes mTLS headers' do
+        expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+        expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
+      end
+
+      context 'when mutual TLS is enabled' do
+        let(:properties) do
+          default_properties.merge({ 'client_cert' => true })
+        end
+
+        it 'always deletes mTLS headers' do
+          expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter')
+        end
+
+        it 'writes mTLS headers when mTLS is used' do
+          expect(frontend_https).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
+        end
+      end
     end
 
-    it 'deletes the X-Forwarded-Client-Cert header for non-route service requests' do
-      expect(frontend_https).to include('acl route_service_request hdr(X-Cf-Proxy-Signature) -m found')
-      expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert if !route_service_request')
-      expect(frontend_https).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }')
+    context 'when ha_proxy.forwarded_client_cert is forward_only_if_route_service' do
+      let(:properties) do
+        default_properties.merge({ 'forwarded_client_cert' => 'forward_only_if_route_service' })
+      end
+
+      it 'deletes mTLS headers for non-route service requests (for mTLS and non-mTLS)' do
+        expect(frontend_https).to include('acl route_service_request hdr(X-Cf-Proxy-Signature) -m found')
+        expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client            if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify     if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore  if !route_service_request')
+        expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter   if !route_service_request')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+        expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
+      end
+
+      context 'when mutual TLS is enabled' do
+        let(:properties) do
+          default_properties.merge({
+            'client_cert' => true,
+            'forwarded_client_cert' => 'forward_only_if_route_service'
+          })
+        end
+
+        it 'deletes mTLS headers for non-route service requests (for mTLS and non-mTLS)' do
+          expect(frontend_https).to include('acl route_service_request hdr(X-Cf-Proxy-Signature) -m found')
+          expect(frontend_https).to include('http-request del-header X-Forwarded-Client-Cert if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client            if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Session-ID if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Verify     if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-DN if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Subject-CN if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotBefore  if !route_service_request')
+          expect(frontend_https).to include('http-request del-header X-SSL-Client-NotAfter   if !route_service_request')
+        end
+
+        it 'overwrites mTLS headers when mTLS is used' do
+          expect(frontend_https).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
+          expect(frontend_https).to include('http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
+        end
+      end
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -152,20 +152,50 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
   end
 
-  describe 'X-Forwarded-Client-Cert header' do
-    context 'when forwarded_client_cert is always_forward_only (the default)' do
-      it 'deletes the X-Forwarded-Client-Cert header by default' do
-        expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
+  describe 'ha_proxy.forwarded_client_cert' do
+    context 'when ha_proxy.forwarded_client_cert is always_forward_only' do
+      let(:properties) do
+        default_properties.merge({ 'forwarded_client_cert' => 'always_forward_only' })
+      end
+
+      it 'does not delete mTLS headers' do
+        expect(frontend_wss).not_to include('http-request del-header X-Forwarded-Client-Cert')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-Session-ID')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-Verify')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-Subject-DN')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-Subject-CN')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-Issuer-DN')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-NotBefore')
+        expect(frontend_wss).not_to include('http-request del-header X-SSL-Client-NotAfter')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_wss).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
+        expect(frontend_wss).not_to include(/http-request set-header X-SSL-Client/)
       end
     end
 
-    context 'when forwarded_client_cert is forward_only' do
+    context 'when ha_proxy.forwarded_client_cert is forward_only' do
       let(:properties) do
         default_properties.merge({ 'forwarded_client_cert' => 'forward_only' })
       end
 
-      it 'deletes the X-Forwarded-Client-Cert header' do
+      it 'deletes mTLS headers' do
         expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_wss).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
+        expect(frontend_wss).not_to include(/http-request set-header X-SSL-Client/)
       end
 
       context 'when mutual TLS is enabled' do
@@ -176,32 +206,128 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
           })
         end
 
-        it 'only deletes the X-Forwarded-Client-Cert header when mTLS is not used' do
+        it 'deletes mTLS headers when mTLS is not used' do
           expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client            if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify     if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN  if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore  if ! { ssl_c_used }')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter   if ! { ssl_c_used }')
+        end
+
+        it 'does not add mTLS headers' do
+          expect(frontend_wss).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
+          expect(frontend_wss).not_to include(/http-request set-header X-SSL-Client/)
         end
       end
     end
 
-    context 'when forwarded_client_cert is sanitize_set' do
-      let(:properties) do
-        default_properties.merge({ 'forwarded_client_cert' => 'sanitize_set' })
+    context 'when ha_proxy.forwarded_client_cert is sanitize_set (the default)' do
+      it 'always deletes mTLS headers' do
+        expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter')
       end
 
-      it 'deletes the X-Forwarded-Client-Cert header' do
-        expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
+      it 'does not add mTLS headers' do
+        expect(frontend_wss).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
+        expect(frontend_wss).not_to include(/http-request set-header X-SSL-Client/)
+      end
+
+      context 'when mutual TLS is enabled' do
+        let(:properties) do
+          default_properties.merge({ 'client_cert' => true })
+        end
+
+        it 'always deletes mTLS headers' do
+          expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter')
+        end
+
+        it 'writes mTLS headers when mTLS is used' do
+          expect(frontend_wss).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
+        end
+      end
+    end
+
+    context 'when ha_proxy.forwarded_client_cert is forward_only_if_route_service' do
+      let(:properties) do
+        default_properties.merge({ 'forwarded_client_cert' => 'forward_only_if_route_service' })
+      end
+
+      it 'deletes mTLS headers for non-route service requests (for mTLS and non-mTLS)' do
+        expect(frontend_wss).to include('acl route_service_request hdr(X-Cf-Proxy-Signature) -m found')
+        expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client            if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify     if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore  if !route_service_request')
+        expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter   if !route_service_request')
+      end
+
+      it 'does not add mTLS headers' do
+        expect(frontend_wss).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
+        expect(frontend_wss).not_to include(/http-request set-header X-SSL-Client/)
       end
 
       context 'when mutual TLS is enabled' do
         let(:properties) do
           default_properties.merge({
             'client_cert' => true,
-            'forwarded_client_cert' => 'sanitize_set'
+            'forwarded_client_cert' => 'forward_only_if_route_service'
           })
         end
 
-        it 'sets X-Forwarded-Client-Cert to the client cert for mTLS connections ' do
-          expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert')
-          expect(frontend_wss).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64] if { ssl_c_used }')
+        it 'deletes mTLS headers for non-route service requests (for mTLS and non-mTLS)' do
+          expect(frontend_wss).to include('acl route_service_request hdr(X-Cf-Proxy-Signature) -m found')
+          expect(frontend_wss).to include('http-request del-header X-Forwarded-Client-Cert if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client            if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Session-ID if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Verify     if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-DN if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Subject-CN if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-Issuer-DN  if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotBefore  if !route_service_request')
+          expect(frontend_wss).to include('http-request del-header X-SSL-Client-NotAfter   if !route_service_request')
+        end
+
+        it 'overwrites mTLS headers when mTLS is used' do
+          expect(frontend_wss).to include('http-request set-header X-Forwarded-Client-Cert %[ssl_c_der,base64]      if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client            %[ssl_c_used]            if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Session-ID %[ssl_fc_session_id,hex] if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Verify     %[ssl_c_verify]          if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Subject-DN %{+Q}[ssl_c_s_dn]        if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Subject-CN %{+Q}[ssl_c_s_dn(cn)]    if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-Issuer-DN  %{+Q}[ssl_c_i_dn]        if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-NotBefore  %{+Q}[ssl_c_notbefore]   if { ssl_c_used }')
+          expect(frontend_wss).to include('http-request set-header X-SSL-Client-NotAfter   %{+Q}[ssl_c_notafter]    if { ssl_c_used }')
         end
       end
     end


### PR DESCRIPTION
Changes:

* `X-SSL-Client-*` headers describing client certificate will only be added when `ha_proxy.forwarded_client_cert` also requires that the `X-Forwarded-Client-Cert` is overwritten with the client certificate info.
* `X-SSL-Client-*` headers will be stripped from incoming requests if `ha_proxy.forwarded_client_cert` is `sanitize_set`
* Update spec to clarify when `X-SSL-Client-*` headers are added / overwritten
* Refactor `ha_proxy.config` to simplify `ha_proxy.forwarded_client_cert` implementation
* Update `ha_proxy.config` websockets  frontend `X-SSL-Client-*` header behaviour to match https frontend behaviour
* Update units tests to test new functionality and to fix following mistake: Unit tests mistakenly [stated](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/blob/master/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb#L181) that `ha_proxy.forwarded_client_cert` is _always_forward_only_ by default, but then the test implementation tested the bahaviour of _sanitize_set_, which is the actual default. 
* Update `acceptance-tests/xfcc_test.go` to test new functionality as well as extract some shared logic to simplify test implementation