### PR TITLE
Do not require SNIs when disable_domain_fronting is true

### DIFF
--- a/acceptance-tests/domain_fronting_test.go
+++ b/acceptance-tests/domain_fronting_test.go
@@ -1,6 +1,7 @@
 package acceptance_tests
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ var _ = Describe("Domain fronting", func() {
 # Disable domain fronting
 - type: replace
   path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/disable_domain_fronting?
-  value: true
+  value: ((disable_domain_fronting))
 # Configure CA and cert chain
 - type: replace
   path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
@@ -25,6 +26,7 @@ var _ = Describe("Domain fronting", func() {
     ssl_pem:
       cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
       private_key: ((https_frontend.private_key))
+    client_ca_file: ((client_cert.ca))
 # Declare certs
 - type: replace
   path: /variables?/-
@@ -43,115 +45,199 @@ var _ = Describe("Domain fronting", func() {
       ca: https_frontend_ca
       common_name: ((cert_common_name))
       alternative_names: ((cert_sans))
+- type: replace
+  path: /variables?/-
+  value:
+    name: client_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: client_cert
+    type: certificate
+    options:
+      ca: client_ca
+      common_name: client
+      alternative_names: [client]
+      extended_key_usage: [client_auth]
 `
 
 	var creds struct {
 		HTTPSFrontend struct {
-			Certificate string `yaml:"certificate"`
-			PrivateKey  string `yaml:"private_key"`
-			CA          string `yaml:"ca"`
-		} `yaml:"https_frontend"`
+			Certificate string `yaml:"certificate" json:"certificate"`
+			PrivateKey  string `yaml:"private_key" json:"private_key"`
+			CA          string `yaml:"ca" json:"ca"`
+		} `yaml:"https_frontend" json:"https_frontend"`
 		HTTPSFrontendCA struct {
-			Certificate string `yaml:"certificate"`
-			PrivateKey  string `yaml:"private_key"`
-		} `yaml:"https_frontend_ca"`
+			Certificate string `yaml:"certificate" json:"certificate"`
+			PrivateKey  string `yaml:"private_key" json:"private_key"`
+		} `yaml:"https_frontend_ca" json:"https_frontend_ca"`
+		Client struct {
+			Certificate string `yaml:"certificate" json:"certificate"`
+			PrivateKey  string `yaml:"private_key" json:"private_key"`
+			CA          string `yaml:"ca" json:"ca"`
+		} `yaml:"client_cert" json:"client_cert"`
+		ClientCA struct {
+			Certificate string `yaml:"certificate" json:"certificate"`
+			PrivateKey  string `yaml:"private_key" json:"private_key"`
+		} `yaml:"client_ca" json:"client_ca"`
 	}
+	var disableDomainFronting interface{}
+	var haproxyInfo haproxyInfo
+	var closeLocalServer func()
+	var closeSSHTunnel context.CancelFunc
+	var clientCert tls.Certificate
+	var mtlsClient *http.Client
+	var nonMTLSClient *http.Client
+	var mtlsClientNoSNI *http.Client
+	var nonMTLSClientNoSNI *http.Client
+	haproxyBackendPort := 12000
 
-	It("Disables domain fronting", func() {
-		haproxyBackendPort := 12000
-		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
-			haproxyBackendPort:    haproxyBackendPort,
-			haproxyBackendServers: []string{"127.0.0.1"},
-			deploymentName:        defaultDeploymentName,
-		}, []string{opsfile}, map[string]interface{}{
-			"cert_common_name": "haproxy.internal",
-			"cert_sans":        []string{"haproxy.internal"},
-		}, true)
-
-		err := varsStoreReader(&creds)
-		Expect(err).NotTo(HaveOccurred())
-
-		closeLocalServer, localPort := startDefaultTestServer()
-		defer closeLocalServer()
-
-		closeTunnel := setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
-		defer closeTunnel()
-
-		httpClient := buildHTTPClient(
-			[]string{creds.HTTPSFrontend.CA},
-			map[string]string{
-				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
-			},
-			[]tls.Certificate{},
-		)
-
-		By("Sending a request to HAProxy with a mismatched SNI and Host header it returns a 421")
-		req, err := http.NewRequest("GET", "https://haproxy.internal", nil)
-		Expect(err).NotTo(HaveOccurred())
-		req.Host = "spoof.internal"
-
-		resp, err := httpClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusMisdirectedRequest))
-
-		By("Sending a request to HAProxy with a matching Host header it returns a 200 as normal")
-		req, err = http.NewRequest("GET", "https://haproxy.internal", nil)
-		Expect(err).NotTo(HaveOccurred())
-		req.Host = "haproxy.internal"
-		resp, err = httpClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
-
-		By("Sending a request to HAProxy with a matching Host header including the optional port it returns a 200 as normal")
-		req, err = http.NewRequest("GET", "https://haproxy.internal", nil)
-		Expect(err).NotTo(HaveOccurred())
-		req.Host = "haproxy.internal:443"
-
-		resp, err = httpClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
-
-		By("Sending a request to HAProxy with no SNI it returns a 200, regardless of host header")
-		haproxyIP := haproxyInfo.PublicIP
-
-		// Requests that use an IP rather than a hostname do not send an SNI.
-		// However the IP of HAProxy is not known until deploy time.
-		// After the first deploy, BOSH won't change the IP, so we will now
-		// redeploy and update the cert to include the IP
+	JustBeforeEach(func() {
+		var varsStoreReader varsStoreReader
 		haproxyInfo, varsStoreReader = deployHAProxy(baseManifestVars{
 			haproxyBackendPort:    haproxyBackendPort,
 			haproxyBackendServers: []string{"127.0.0.1"},
 			deploymentName:        defaultDeploymentName,
 		}, []string{opsfile}, map[string]interface{}{
-			// Update cert to include public IP
-			"cert_common_name": haproxyIP,
-			"cert_sans":        []string{haproxyIP, "haproxy.internal"},
-			// Keep previous CA so we can re-use HTTP client
-			"https_frontend_ca": map[string]string{
-				"certificate": creds.HTTPSFrontendCA.Certificate,
-				"private_key": creds.HTTPSFrontendCA.PrivateKey,
-			},
+			"disable_domain_fronting": disableDomainFronting,
+			"cert_common_name":        "haproxy.internal",
+			"cert_sans":               []string{"haproxy.internal"},
 		}, true)
 
-		err = varsStoreReader(&creds)
+		err := varsStoreReader(&creds)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Confirm IP has not changed
-		Expect(haproxyInfo.PublicIP).To(Equal(haproxyIP))
+		var localPort int
+		closeLocalServer, localPort = startDefaultTestServer()
+		closeSSHTunnel = setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
 
-		req, err = http.NewRequest("GET", fmt.Sprintf("https://%s", haproxyIP), nil)
+		clientCert, err = tls.X509KeyPair([]byte(creds.Client.Certificate), []byte(creds.Client.PrivateKey))
 		Expect(err).NotTo(HaveOccurred())
 
-		// Although we are using a 'spoofed' host header here, HAProxy
-		// should not care as there is no SNI in the request
-		req.Host = "spoof.internal"
+		nonMTLSClient = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{
+				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
+			},
+			[]tls.Certificate{}, "",
+		)
 
-		resp, err = httpClient.Do(req)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		mtlsClient = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{
+				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
+			},
+			[]tls.Certificate{clientCert}, "",
+		)
+
+		nonMTLSClientNoSNI = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{
+				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
+			},
+			[]tls.Certificate{}, "1.2.3.4",
+		)
+
+		mtlsClientNoSNI = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{
+				"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
+			},
+			[]tls.Certificate{clientCert}, "1.2.3.4",
+		)
+	})
+
+	AfterEach(func() {
+		if closeLocalServer != nil {
+			defer closeLocalServer()
+		}
+
+		if closeSSHTunnel != nil {
+			defer closeSSHTunnel()
+		}
+	})
+
+	Context("When disable domain fronting is true", func() {
+		BeforeEach(func() {
+			disableDomainFronting = true
+		})
+
+		It("Disables domain fronting", func() {
+			By("Sending a request to HAProxy with a mismatched SNI and Host header it returns a 421")
+			req := buildRequest("https://haproxy.internal", "spoof.internal")
+			expect421(req, nonMTLSClient)
+			expect421(req, mtlsClient)
+
+			By("Sending a request to HAProxy with a matching Host header it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal")
+			expect200(req, nonMTLSClient)
+			expect200(req, mtlsClient)
+
+			By("Sending a request to HAProxy with a matching Host header including the optional port it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal:443")
+			expect200(req, nonMTLSClient)
+			expect200(req, mtlsClient)
+
+			By("Sending a request to HAProxy with no SNI it returns a 200, regardless of host header")
+			// Although we are using a 'spoofed' host header here, HAProxy
+			// should not care as there is no SNI in the request
+			req = buildRequest("https://haproxy.internal", "spoof.internal")
+			expect200(req, nonMTLSClientNoSNI)
+			expect200(req, mtlsClientNoSNI)
+		})
+	})
+
+	Context("When disable domain fronting is mtls_only", func() {
+		BeforeEach(func() {
+			disableDomainFronting = "mtls_only"
+		})
+
+		It("Disables domain fronting for MTLS requests only", func() {
+			By("Sending a request to HAProxy with a mismatched SNI and Host header it returns a 421 only for mTLS requests")
+			req := buildRequest("https://haproxy.internal", "spoof.internal")
+			expect200(req, nonMTLSClient)
+			expect421(req, mtlsClient)
+
+			By("Sending a request to HAProxy with a matching Host header it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal")
+			expect200(req, nonMTLSClient)
+			expect200(req, mtlsClient)
+
+			By("Sending a request to HAProxy with a matching Host header including the optional port it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal:443")
+			expect200(req, nonMTLSClient)
+			expect200(req, mtlsClient)
+
+			By("Sending a request to HAProxy with no SNI it returns a 200, regardless of host header")
+			// Although we are using a 'spoofed' host header here, HAProxy
+			// should not care as there is no SNI in the request
+			req = buildRequest("https://haproxy.internal", "spoof.internal")
+			expect200(req, nonMTLSClientNoSNI)
+			expect200(req, mtlsClientNoSNI)
+		})
 	})
 })
+
+func buildRequest(address string, hostHeader string) *http.Request {
+	req, err := http.NewRequest("GET", address, nil)
+	Expect(err).NotTo(HaveOccurred())
+	req.Host = hostHeader
+	return req
+}
+
+func expect200(req *http.Request, client *http.Client) {
+	resp, err := client.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
+}
+
+func expect421(req *http.Request, client *http.Client) {
+	resp, err := client.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusMisdirectedRequest))
+}

--- a/acceptance-tests/http.go
+++ b/acceptance-tests/http.go
@@ -32,17 +32,24 @@ func startLocalHTTPServer(handler func(http.ResponseWriter, *http.Request)) (fun
 }
 
 // Build an HTTP client with custom CA certificate pool which resolves hosts based on provided map
-func buildHTTPClient(caCerts []string, addressMap map[string]string, clientCerts []tls.Certificate) *http.Client {
+func buildHTTPClient(caCerts []string, addressMap map[string]string, clientCerts []tls.Certificate, serverName string) *http.Client {
 	caCertPool := x509.NewCertPool()
 	for _, caCert := range caCerts {
 		caCertPool.AppendCertsFromPEM([]byte(caCert))
 	}
 
+	tlsConfig := tls.Config{
+		RootCAs:      caCertPool,
+		Certificates: clientCerts,
+	}
+
+	if serverName != "" {
+		tlsConfig.ServerName = serverName
+		tlsConfig.InsecureSkipVerify = true
+	}
+
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs:      caCertPool,
-			Certificates: clientCerts,
-		},
+		TLSClientConfig: &tlsConfig,
 		// Override DialContext to force resolve with alternative addresses
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			if altAddr, ok := addressMap[addr]; ok {
@@ -62,7 +69,7 @@ func buildHTTPClient(caCerts []string, addressMap map[string]string, clientCerts
 // Build an HTTP2 client with custom CA certificate pool which resolves hosts based on provided map
 func buildHTTP2Client(caCerts []string, addressMap map[string]string, clientCerts []tls.Certificate) *http.Client {
 
-	httpClient := buildHTTPClient(caCerts, addressMap, clientCerts)
+	httpClient := buildHTTPClient(caCerts, addressMap, clientCerts, "")
 	transport := httpClient.Transport.(*http.Transport)
 	http2.ConfigureTransport(transport)
 

--- a/acceptance-tests/https_ext_crt_list_test.go
+++ b/acceptance-tests/https_ext_crt_list_test.go
@@ -140,7 +140,7 @@ var _ = Describe("External Certificate Lists", func() {
 				"cert_b.haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
 				"cert_c.haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
 			},
-			[]tls.Certificate{},
+			[]tls.Certificate{}, "",
 		)
 
 		By("Sending a request to HAProxy using internal cert A works (default cert)")
@@ -333,7 +333,7 @@ var _ = Describe("External Certificate Lists", func() {
 				client := buildHTTPClient(
 					[]string{creds.Cert.CA},
 					map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
-					[]tls.Certificate{},
+					[]tls.Certificate{}, "",
 				)
 
 				By("Sending a request to HAProxy using the external cert")
@@ -419,7 +419,7 @@ var _ = Describe("External Certificate Lists", func() {
 					client := buildHTTPClient(
 						[]string{creds.Cert.CA},
 						map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
-						[]tls.Certificate{},
+						[]tls.Certificate{}, "",
 					)
 
 					By("Sending a request to HAProxy using the external cert")

--- a/acceptance-tests/https_frontend_test.go
+++ b/acceptance-tests/https_frontend_test.go
@@ -80,7 +80,7 @@ var _ = Describe("HTTPS Frontend", func() {
 		http1Client = buildHTTPClient(
 			[]string{creds.HTTPSFrontend.CA},
 			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
-			[]tls.Certificate{},
+			[]tls.Certificate{}, "",
 		)
 	})
 

--- a/acceptance-tests/mtls_frontend_test.go
+++ b/acceptance-tests/mtls_frontend_test.go
@@ -147,14 +147,14 @@ var _ = Describe("mTLS", func() {
 			"b.haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP),
 		}
 
-		httpClientA := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{clientCertA})
+		httpClientA := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{clientCertA}, "")
 
 		clientCertB, err := tls.X509KeyPair([]byte(creds.ClientB.Certificate), []byte(creds.ClientB.PrivateKey))
 		Expect(err).NotTo(HaveOccurred())
 
-		httpClientB := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{clientCertB})
+		httpClientB := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{clientCertB}, "")
 
-		httpClientNonMTLS := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{})
+		httpClientNonMTLS := buildHTTPClient([]string{creds.HTTPSFrontend.CA}, addressMap, []tls.Certificate{}, "")
 
 		By("Using client A cert with endpoint A works")
 		resp, err := httpClientA.Get("https://a.haproxy.internal")

--- a/acceptance-tests/xfcc_test.go
+++ b/acceptance-tests/xfcc_test.go
@@ -162,13 +162,13 @@ var _ = Describe("forwarded_client_cert", func() {
 		nonMTLSClient = buildHTTPClient(
 			[]string{creds.HTTPSFrontend.CA},
 			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
-			[]tls.Certificate{},
+			[]tls.Certificate{}, "",
 		)
 
 		mtlsClient = buildHTTPClient(
 			[]string{creds.HTTPSFrontend.CA},
 			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
-			[]tls.Certificate{clientCert},
+			[]tls.Certificate{clientCert}, "",
 		)
 
 		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -73,9 +73,11 @@ properties:
     default: false
   ha_proxy.disable_domain_fronting:
     description: |
+      Must be one of true, false, or "mtls_only"
       If set to true, it will prevent clients from setting a host header different from the SNI value for HTTPS and WSS (secured websockets) connections. This is called domain fronting and is mostly used by CDNs.
       If domain fronting is disabled, such requests will result in a 421 Misdirected Request error.
-      Example:
+      If set to "mtls_only", the host header will only be checked against the SNI for mtls connections
+      Example
         curl -H "Host: bob.com" https://alice.com    <-- This will result in a 421 Misdirected Request
     default: false
   ha_proxy.ssl_pem:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -108,6 +108,11 @@ else
   abort("Unknown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set', 'forward_only_if_route_service'")
 end
 
+disable_domain_fronting = p("ha_proxy.disable_domain_fronting")
+if ![true, false, "true", "false", "mtls_only"].include?(disable_domain_fronting)
+  abort("Unknown 'disable_domain_fronting' option: #{disable_domain_fronting}. Known options: true, false or 'mtls_only'")
+end
+
 # }}}
 # IPv4 and IPv6 binding (v4v6) Option {{{
 v4v6 = ""
@@ -343,12 +348,18 @@ frontend https-in
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %> <%= alpn_config %>
-  <%- if p("ha_proxy.disable_domain_fronting")-%>
+  <%- if disable_domain_fronting -%>
     # Check whether the client is attempting domain fronting.
+    # Ensure a host header exists to check against
+    http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
     http-request set-var(txn.host) hdr(host),field(1,:)
     acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    <%- if disable_domain_fronting  == 'mtls_only' %>
+    http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match
+    <%- elsif [true, "true"].include?(disable_domain_fronting) -%>
     http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match
+    <%- end -%>
   <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -465,12 +476,18 @@ frontend wss-in
     grace <%= (p("ha_proxy.drain_frontend_grace_time").to_f    * 1000).to_i %>
   <%- end -%>
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
-  <%- if p("ha_proxy.disable_domain_fronting")-%>
+  <%- if disable_domain_fronting -%>
     # Check whether the client is attempting domain fronting.
+    # Ensure a host header exists to check against
+    http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
     http-request set-var(txn.host) hdr(host),field(1,:)
     acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    <%- if disable_domain_fronting  == 'mtls_only' %>
+    http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match
+    <%- elsif [true, "true"].include?(disable_domain_fronting) -%>
     http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match
+    <%- end -%>
   <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -345,9 +345,10 @@ frontend https-in
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %> <%= alpn_config %>
   <%- if p("ha_proxy.disable_domain_fronting")-%>
     # Check whether the client is attempting domain fronting.
-    http-request set-var(txn.host) hdr(host)
+    # Ignore optional port in Host header when comparing to SNI
+    http-request set-var(txn.host) hdr(host),field(1,:)
     acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
-    http-request deny deny_status 421 unless ssl_sni_http_host_match
+    http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match
   <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>
@@ -466,9 +467,10 @@ frontend wss-in
     bind <%= p("ha_proxy.binding_ip") %>:4443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %>
   <%- if p("ha_proxy.disable_domain_fronting")-%>
     # Check whether the client is attempting domain fronting.
-    http-request set-var(txn.host) hdr(host)
+    # Ignore optional port in Host header when comparing to SNI
+    http-request set-var(txn.host) hdr(host),field(1,:)
     acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
-    http-request deny deny_status 421 unless ssl_sni_http_host_match
+    http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match
   <%- end -%>
   <%- if properties.ha_proxy.frontend_config -%>
     <%= p("ha_proxy.frontend_config") %>

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -96,6 +96,36 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
   end
 
+  context 'when ha_proxy.disable_domain_fronting is mtls_only' do
+    let(:properties) do
+      default_properties.merge({ 'disable_domain_fronting' => 'mtls_only' })
+    end
+
+    it 'disables domain fronting by checkig SNI against the Host header for mtls connections only' do
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
+      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+      expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match')
+    end
+  end
+
+  context 'when ha_proxy.disable_domain_fronting is false (the default)' do
+    it 'allows domain fronting' do
+      expect(frontend_https).not_to include(/http-request deny deny_status 421/)
+    end
+  end
+
+  context 'when ha_proxy.disable_domain_fronting is an invalid value' do
+    let(:properties) do
+      default_properties.merge({ 'disable_domain_fronting' => 'foobar' })
+    end
+
+    it 'aborts with a meaningful error message' do
+      expect do
+        frontend_https
+      end.to raise_error /Unknown 'disable_domain_fronting' option: foobar. Known options: true, false or 'mtls_only'/
+    end
+  end
+
   context 'when mutual tls is disabled' do
     let(:properties) do
       default_properties.merge({ 'client_cert' => false })

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -90,9 +90,9 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
 
     it 'disables domain fronting by checkig SNI against the Host header' do
-      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host)')
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
       expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
-      expect(frontend_https).to include('http-request deny deny_status 421 unless ssl_sni_http_host_match')
+      expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -92,9 +92,9 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
     end
 
     it 'disables domain fronting by checkig SNI against the Host header' do
-      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host)')
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
       expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
-      expect(frontend_wss).to include('http-request deny deny_status 421 unless ssl_sni_http_host_match')
+      expect(frontend_wss).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
   end
 


### PR DESCRIPTION
`ha_proxy.disable_domain_fronting` should not require an SNI. However when an SNI is provided, it should reject mismatched Host and SNI.

* This update also fixes the SNI check so that a Host header that includes the optional port suffix (`myhost.com:443`) is checked correctly.
* This update also adds an option to `ha_proxy.disable_domain_fronting` so that domain fronting is only checked for mtls connections