### PR TITLE
Allow disabling TLSv1.2

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -230,6 +230,9 @@ properties:
   ha_proxy.disable_tls_11:
     default: false
     description: "Disable TLS 1.1 in HA Proxy"
+  ha_proxy.disable_tls_12:
+    default: false
+    description: "Disable TLS 1.2 in HA Proxy"
 
   ha_proxy.connect_timeout:
     description: "Timeout (in floating point seconds) used on connections from haproxy to a backend, while waiting for the TCP handshake to complete + connection to establish"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -28,6 +28,9 @@ end
 if p("ha_proxy.disable_tls_11")
   ssl_flags = "#{ssl_flags} no-tlsv11"
 end
+if p("ha_proxy.disable_tls_12")
+  ssl_flags = "#{ssl_flags} no-tlsv12"
+end
 if p("ha_proxy.disable_tls_tickets")
   ssl_flags = "#{ssl_flags} no-tls-tickets"
 end

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -192,6 +192,19 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
+  context 'when ha_proxy.disable_tls_12 is provided' do
+    let(:properties) do
+      {
+        'disable_tls_12' => true
+      }
+    end
+
+    it 'disables TLS 1.2' do
+      expect(global).to include('ssl-default-server-options no-sslv3 no-tlsv12 no-tls-tickets')
+      expect(global).to include('ssl-default-bind-options no-sslv3 no-tlsv12 no-tls-tickets')
+    end
+  end
+
   context 'when ha_proxy.disable_tls_tickets is provided' do
     let(:properties) do
       {


### PR DESCRIPTION
This allows consumers to disable TLSv1.2 in an environment where they require TLSv1.3+.