### PR TITLE
Allow disabling TLSv1.3

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -233,6 +233,9 @@ properties:
   ha_proxy.disable_tls_12:
     default: false
     description: "Disable TLS 1.2 in HA Proxy"
+  ha_proxy.disable_tls_13:
+    default: false
+    description: "Disable TLS 1.3 in HA Proxy"
 
   ha_proxy.connect_timeout:
     description: "Timeout (in floating point seconds) used on connections from haproxy to a backend, while waiting for the TCP handshake to complete + connection to establish"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -31,6 +31,9 @@ end
 if p("ha_proxy.disable_tls_12")
   ssl_flags = "#{ssl_flags} no-tlsv12"
 end
+if p("ha_proxy.disable_tls_13")
+  ssl_flags = "#{ssl_flags} no-tlsv13"
+end
 if p("ha_proxy.disable_tls_tickets")
   ssl_flags = "#{ssl_flags} no-tls-tickets"
 end

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -205,6 +205,19 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
+  context 'when ha_proxy.disable_tls_13 is provided' do
+    let(:properties) do
+      {
+        'disable_tls_13' => true
+      }
+    end
+
+    it 'disables TLS 1.3' do
+      expect(global).to include('ssl-default-server-options no-sslv3 no-tlsv13 no-tls-tickets')
+      expect(global).to include('ssl-default-bind-options no-sslv3 no-tlsv13 no-tls-tickets')
+    end
+  end
+
   context 'when ha_proxy.disable_tls_tickets is provided' do
     let(:properties) do
       {


### PR DESCRIPTION
This allows consumers to disable TLSv1.3 in an environment where they require < TLSv1.3.