### PR TITLE
Add lua_scripts_per_thread property

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -510,6 +510,36 @@ properties:
       A list of LUA scripts that HA Proxy should load. These will need to be provided
       by other boshreleases, as none are supplied in `haproxy_boshrelease`. Specify
       each script with the full path to the script (likely `/var/vcap/packages/something/something/darkside.lua`)
+
+      Inside these scripts, any variable set is visible
+      from any thread. This is the easiest and recommended way to load Lua programs
+      but it will not scale well if a lot of Lua calls are performed, as only one
+      thread may be running on the global state at a time. A program loaded this
+      way will always see 0 in the "core.thread" variable. This directive can be
+      used multiple times.
+
+    default: []
+
+  ha_proxy.lua_scripts_per_thread:
+    description: |
+      A list of LUA scripts that HA Proxy should load per thread. These will need to be provided
+      by other boshreleases, as none are supplied in `haproxy_boshrelease`. Specify
+      each script with the full path to the script (likely `/var/vcap/packages/something/something/darkside.lua`).
+
+      Inside these scripts, any global variable has a thread-local visibility so that each thread could
+      see a different value. As such it is strongly recommended not to use global
+      variables in programs loaded this way. An independent copy is loaded and
+      initialized for each thread, everything is done sequentially and in the
+      thread's numeric order from 1 to nbthread. If some operations need to be
+      performed only once, the program should check the "core.thread" variable to
+      figure what thread is being initialized. Programs loaded this way will run
+      concurrently on all threads and will be highly scalable. This is the
+      recommended way to load simple functions that register sample-fetches,
+      converters, actions or services once it is certain the program doesn't depend
+      on global variables. For the sake of simplicity, the directive is available
+      even if only one thread is used and even if threads are disabled (in which
+      case it will be equivalent to `lua_scripts`).
+
     default: []
 
   ha_proxy.additional_unrestricted_volumes:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -196,6 +196,9 @@ global
   <%- p("ha_proxy.lua_scripts").each do |script| -%>
     lua-load <%= script %>
   <%- end -%>
+  <%- p("ha_proxy.lua_scripts_per_thread").each do |script| -%>
+    lua-load-per-thread <%= script %>
+  <%- end -%>
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
     tune.bufsize <%= p("ha_proxy.buffer_size_bytes") %>
   <%- if_p("ha_proxy.max_rewrite") do -%>

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -283,6 +283,20 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
+  context 'when ha_proxy.lua_scripts_per_thread is provided' do
+    let(:properties) do
+      {
+        'lua_scripts_per_thread' => [
+          '/var/vcap/packages/something/something/darkside.lua'
+        ]
+      }
+    end
+
+    it 'includes the external lua script' do
+      expect(global).to include('lua-load-per-thread /var/vcap/packages/something/something/darkside.lua')
+    end
+  end
+
   context 'when ha_proxy.default_dh_param is provided' do
     let(:properties) do
       {


### PR DESCRIPTION
~Requires https://github.com/cloudfoundry-incubator/haproxy-boshrelease/pull/233 is merged first as this has a dependency on HAProxy 2.4+~

Adds `lua_scripts_per_thread` property which corresponds to HAProxy new `lua-load-per-thread` config property.

Existing `lua_scripts` property remains unchanged.

Also updates spec with caveats from HAProxy docs about use of [lua-load](https://cbonte.github.io/haproxy-dconv/2.4/configuration.html#lua-load) and [lua-load-per-thread](https://cbonte.github.io/haproxy-dconv/2.4/configuration.html#lua-load-per-thread).

These changes have been tested manually (`lua_scripts` and `lua_scripts_per_thread` don't seem complex enough to require an acceptance tests since the BOSH release doesn't do much other than pass the configuration values straight to the HAProxy config)