### PR TITLE
Also ignore ca errors when ignoring crt errors

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -393,7 +393,7 @@ properties:
       -----END PRIVATE KEY-----
 
   ha_proxy.client_cert_ignore_err:
-    description: "Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a pipe-separated list. For example, 2 is if it cannot get the issuer certificate, 10 if the certificate has expired and 18 if the certificate is self-signed. The keyword 'all' will ignore all possible errors. See the openssl verify documentation [https://wiki.openssl.org/index.php/Manual:Verify(1)] for a full list of all error codes and their meanings."
+    description: "Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a pipe-separated list. For example, 2 is if it cannot get the issuer certificate, 10 if the certificate has expired and 18 if the certificate is self-signed. The keyword 'all' will ignore all possible errors. See the openssl verify documentation [https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get_error.html] for a full list of all error codes and their meanings."
     example: 2|10|18
 
   ha_proxy.client_revocation_list:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -393,7 +393,13 @@ properties:
       -----END PRIVATE KEY-----
 
   ha_proxy.client_cert_ignore_err:
-    description: "Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a pipe-separated list. For example, 2 is if it cannot get the issuer certificate, 10 if the certificate has expired and 18 if the certificate is self-signed. The keyword 'all' will ignore all possible errors. See the openssl verify documentation [https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get_error.html] for a full list of all error codes and their meanings."
+    description: |
+      Error code(s) to ignore from verifying a client cert during a mutual ssl handshake, in a pipe-separated list.
+      For example, 2 is if it cannot get the issuer certificate, 10 if the certificate has expired and 18 if the certificate is self-signed.
+      The keyword 'all' will ignore all possible errors.
+      Note that the errors will be ignored on both the certificate and the CA verification.
+      See the openssl verify documentation [https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get_error.html] for a full list of all error codes and their meanings.
+      See https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in#L206 for a mapping of error codes to symbols.
     example: 2|10|18
 
   ha_proxy.client_revocation_list:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -82,6 +82,7 @@ if mutual_tls_enabled
   tls_options = "#{tls_options} ca-file #{client_ca_certs} verify optional"
   if_p("ha_proxy.client_cert_ignore_err") do |ignore_errs|
     tls_options = "#{tls_options} crt-ignore-err #{ignore_errs}"
+    tls_options = "#{tls_options} ca-ignore-err #{ignore_errs}"
   end
   if_p("ha_proxy.client_revocation_list") do
     tls_options = "#{tls_options} crl-file /var/vcap/jobs/haproxy/config/client-revocation-list.pem"

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -130,7 +130,7 @@ describe 'config/haproxy.config HTTPS frontend' do
     end
 
     it 'does not add mTLS headers' do
-      expect(frontend_https).not_to include(/http-request set-header X-Fowarded-Client-Cert/)
+      expect(frontend_https).not_to include(/http-request set-header X-Forwarded-Client-Cert/)
       expect(frontend_https).not_to include(/http-request set-header X-SSL-Client/)
     end
   end
@@ -144,18 +144,18 @@ describe 'config/haproxy.config HTTPS frontend' do
       expect(frontend_https).to include('bind :443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional')
     end
 
-    context 'when ha_proxy.client_cert_ignore_err is true' do
+    context 'when ha_proxy.client_cert_ignore_err is all' do
       let(:properties) do
-        default_properties.merge({ 'client_cert' => true, 'client_cert_ignore_err' => true })
+        default_properties.merge({ 'client_cert' => true, 'client_cert_ignore_err' => 'all' })
       end
 
-      it 'adds the crt-ignore-err flag' do
-        expect(frontend_https).to include('bind :443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crt-ignore-err true')
+      it 'adds the crt-ignore-err and ca-ignore-err flags' do
+        expect(frontend_https).to include('bind :443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crt-ignore-err all ca-ignore-err all')
       end
 
       context 'when client_cert is not enabled' do
         let(:properties) do
-          default_properties.merge({ 'client_cert_ignore_err' => true })
+          default_properties.merge({ 'client_cert_ignore_err' => 'all' })
         end
 
         it 'aborts with a meaningful error message' do

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -135,13 +135,13 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional')
     end
 
-    context 'when ha_proxy.client_cert_ignore_err is true' do
+    context 'when ha_proxy.client_cert_ignore_err is all' do
       let(:properties) do
-        default_properties.merge({ 'client_cert' => true, 'client_cert_ignore_err' => true })
+        default_properties.merge({ 'client_cert' => true, 'client_cert_ignore_err' => 'all' })
       end
 
-      it 'adds the crt-ignore-err flag' do
-        expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crt-ignore-err true')
+      it 'adds the crt-ignore-err and ca-ignore-err flags' do
+        expect(frontend_wss).to include('bind :4443  ssl crt /var/vcap/jobs/haproxy/config/ssl  ca-file /etc/ssl/certs/ca-certificates.crt verify optional crt-ignore-err all ca-ignore-err all')
       end
 
       context 'when client_cert is not enabled' do


### PR DESCRIPTION
This will allow us to forward non-verifying mTLS certificates to a proper ACL or lua script later.
It seems, only `crt-ignore-err` doesn't catch all possible errors and you can still end up with `tlsv1 alert unknown ca` errors that don't tell you anything. 