### PR TITLE
Create alternative release which allows hot patching of haproxy code

### DIFF
--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -109,6 +109,19 @@ fi
  git status
  git commit -m "release v${VERSION}")
 
+# After creating a final release we will also create a dev release with RFC 6455 compliance patch
+pushd ${REPO_ROOT}
+echo "- haproxy/patches.tar.gz" >> packages/haproxy/spec
+tar -czvf haproxy-patches.tar.gz haproxy-patches
+bosh add-blob haproxy-patches.tar.gz haproxy/patches.tar.gz
+bosh upload-blobs
+
+bosh -n create-release --force --version ${VERSION}-patched \
+  --tarball releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION-patched.tgz
+popd
+
+mv ${REPO_ROOT}/releases/$RELEASE_NAME/$RELEASE_NAME-$VERSION-patched.tgz ${RELEASE_ROOT}/artifacts
+
 # so that future steps in the pipeline can push our changes
 cp -a ${REPO_ROOT} ${REPO_OUT}
 

--- a/haproxy-patches/disable-rfc-6455-compliance.patch
+++ b/haproxy-patches/disable-rfc-6455-compliance.patch
@@ -1,0 +1,23 @@
+--- src/mux_h1.c	2021-07-07 15:46:09.000000000 +0100
++++ src/mux_h1.updated.c	2021-08-04 12:29:07.000000000 +0100
+@@ -1396,20 +1396,6 @@
+ 		goto end;
+ 	}
+ 
+-	/* If websocket handshake, search for the websocket key */
+-	if ((h1m->flags & (H1_MF_CONN_UPG|H1_MF_UPG_WEBSOCKET)) ==
+-	    (H1_MF_CONN_UPG|H1_MF_UPG_WEBSOCKET)) {
+-		int ws_ret = h1_search_websocket_key(h1s, h1m, htx);
+-		if (!ws_ret) {
+-			h1s->flags |= H1S_F_PARSING_ERROR;
+-			TRACE_ERROR("missing/invalid websocket key, reject H1 message", H1_EV_RX_DATA|H1_EV_RX_HDRS|H1_EV_H1S_ERR, h1s->h1c->conn, h1s);
+-			h1_capture_bad_message(h1s->h1c, h1s, h1m, buf);
+-
+-			ret = 0;
+-			goto end;
+-		}
+-	}
+-
+ 	if (h1m->err_pos >= 0)  {
+ 		/* Maybe we found an error during the parsing while we were
+ 		 * configured not to block on that, so we have to capture it

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,5 +1,5 @@
-# abort script on any command that exit with a non zero value
-set -e
+# abort script on failures
+set -euxo pipefail
 
 # https://www.lua.org/ftp/lua-5.4.3.tar.gz
 LUA_VERSION=5.4.3
@@ -38,9 +38,27 @@ pushd socat-${SOCAT_VERSION}
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/socat
 popd
 
-echo "Installing HAproxy..."
+echo "Unpacking HAproxy..."
 tar xf haproxy/haproxy-${HAPROXY_VERSION}.tar.gz
 pushd haproxy-${HAPROXY_VERSION}
+  if [ -f ../haproxy/patches.tar.gz ]; then
+    mkdir -p ${BOSH_INSTALL_TARGET}/applied-patches
+    tar xf ../haproxy/patches.tar.gz
+
+    for patchfile in haproxy-patches/*.patch; do
+      echo "Applying patch file ${patchfile}"
+
+      # Conservatively limit patch fuzz factor to 0 to reduce chance of faulty patch
+      patch -F 0 -p0 < ${patchfile}
+
+      # Save patches in install target for inspection later
+      cp ${patchfile} ${BOSH_INSTALL_TARGET}/applied-patches
+    done
+
+    rm -r haproxy-patches
+  fi
+
+  echo "Installing HAproxy..."
   make TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_PCRE2_JIT=yes USE_STATIC_PCRE2=1 USE_ZLIB=1 PCRE2DIR=${BOSH_INSTALL_TARGET} USE_LUA=1 LUA_LIB=${BOSH_INSTALL_TARGET}/lib LUA_INC=${BOSH_INSTALL_TARGET}/include
   cp haproxy ${BOSH_INSTALL_TARGET}/bin/
   chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy


### PR DESCRIPTION
This ships an alternative HAProxy release which skips RFC 6455 compliance. When using this release, websocket requests to HAProxy will not be checked for the `sec-websocket-key` header, which was introduced as a check in HAProxy 2.4.0