### PR TITLE
Ignore host header and SNI case when checking domain fronting

### DIFF
--- a/acceptance-tests/config.go
+++ b/acceptance-tests/config.go
@@ -23,48 +23,48 @@ var config Config
 func loadConfig() (Config, error) {
 	releaseRepoPath, err := getEnvOrFail("REPO_ROOT")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	releaseVersion, err := getEnvOrFail("RELEASE_VERSION")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	boshCACert, err := getEnvOrFail("BOSH_CA_CERT")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	boshClient, err := getEnvOrFail("BOSH_CLIENT")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	boshClientSecret, err := getEnvOrFail("BOSH_CLIENT_SECRET")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	boshEnvironment, err := getEnvOrFail("BOSH_ENVIRONMENT")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	boshPath, err := getEnvOrFail("BOSH_PATH")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	baseManifestPath, err := getEnvOrFail("BASE_MANIFEST_PATH")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	// BOSH commands require HOME is set
 	homePath, err := getEnvOrFail("HOME")
 	if err != nil {
-		return Config{}, nil
+		return Config{}, err
 	}
 
 	return Config{

--- a/acceptance-tests/domain_fronting_test.go
+++ b/acceptance-tests/domain_fronting_test.go
@@ -190,12 +190,19 @@ var _ = Describe("Domain fronting", func() {
 			By("Sending a request to HAProxy with no Host header returns a 400")
 			expect400BadRequestNoHostHeader(haproxyInfo.PublicIP, tlsConfig)
 
-			By("Sending a request to HAProxy with a matching Host header it returns a 200 as normal")
+			By("Sending a request to HAProxy with a matching SNI and Host header it returns a 200 as normal")
 			req = buildRequest("https://haproxy.internal", "haproxy.internal")
 			expect200(nonMTLSClient.Do(req))
 			expect200(mtlsClient.Do(req))
 
-			By("Sending a request to HAProxy with a matching Host header including the optional port it returns a 200 as normal")
+			By("Sending a request to HAProxy with a case-mismatched SNI and Host header it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal")
+			// overwrite host field directly to skip canonicalization
+			req.Host = "HAPROXY.internal"
+			expect200(nonMTLSClient.Do(req))
+			expect200(mtlsClient.Do(req))
+
+			By("Sending a request to HAProxy with a matching SNI and Host header including the optional port it returns a 200 as normal")
 			req = buildRequest("https://haproxy.internal", "haproxy.internal:443")
 			expect200(nonMTLSClient.Do(req))
 			expect200(mtlsClient.Do(req))
@@ -223,12 +230,19 @@ var _ = Describe("Domain fronting", func() {
 			By("Sending a request to HAProxy with no Host header returns a 400")
 			expect400BadRequestNoHostHeader(haproxyInfo.PublicIP, tlsConfig)
 
-			By("Sending a request to HAProxy with a matching Host header it returns a 200 as normal")
+			By("Sending a request to HAProxy with a matching SNI and Host header it returns a 200 as normal")
 			req = buildRequest("https://haproxy.internal", "haproxy.internal")
 			expect200(nonMTLSClient.Do(req))
 			expect200(mtlsClient.Do(req))
 
-			By("Sending a request to HAProxy with a matching Host header including the optional port it returns a 200 as normal")
+			By("Sending a request to HAProxy with a case-mismatched SNI and Host header it returns a 200 as normal")
+			req = buildRequest("https://haproxy.internal", "haproxy.internal")
+			// overwrite host field directly to skip canonicalization
+			req.Host = "HAPROXY.internal"
+			expect200(nonMTLSClient.Do(req))
+			expect200(mtlsClient.Do(req))
+
+			By("Sending a request to HAProxy with a matching SNI and Host header including the optional port it returns a 200 as normal")
 			req = buildRequest("https://haproxy.internal", "haproxy.internal:443")
 			expect200(nonMTLSClient.Do(req))
 			expect200(mtlsClient.Do(req))

--- a/acceptance-tests/http.go
+++ b/acceptance-tests/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -38,7 +39,7 @@ func buildHTTPClient(caCerts []string, addressMap map[string]string, clientCerts
 		TLSClientConfig: tlsConfig,
 		// Override DialContext to force resolve with alternative addresses
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if altAddr, ok := addressMap[addr]; ok {
+			if altAddr, ok := addressMap[strings.ToLower(addr)]; ok {
 				addr = altAddr
 			}
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -363,8 +363,8 @@ frontend https-in
     # Ensure a host header exists to check against
     http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
-    http-request set-var(txn.host) hdr(host),field(1,:)
-    acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    http-request set-var(txn.host) hdr(host),field(1,:),lower
+    acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0
     <%- if disable_domain_fronting  == 'mtls_only' %>
     http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match
     <%- elsif [true, "true"].include?(disable_domain_fronting) -%>
@@ -491,8 +491,8 @@ frontend wss-in
     # Ensure a host header exists to check against
     http-request deny deny_status 400 content-type text/plain string "400 Bad Request: missing required Host header" if { req.hdr_cnt(host) eq 0 }
     # Ignore optional port in Host header when comparing to SNI
-    http-request set-var(txn.host) hdr(host),field(1,:)
-    acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0
+    http-request set-var(txn.host) hdr(host),field(1,:),lower
+    acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0
     <%- if disable_domain_fronting  == 'mtls_only' %>
     http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match
     <%- elsif [true, "true"].include?(disable_domain_fronting) -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -87,9 +87,9 @@ describe 'config/haproxy.config HTTPS frontend' do
       default_properties.merge({ 'disable_domain_fronting' => true })
     end
 
-    it 'disables domain fronting by checkig SNI against the Host header' do
-      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
-      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+    it 'disables domain fronting by checking SNI against the Host header' do
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
   end
@@ -99,9 +99,9 @@ describe 'config/haproxy.config HTTPS frontend' do
       default_properties.merge({ 'disable_domain_fronting' => 'mtls_only' })
     end
 
-    it 'disables domain fronting by checkig SNI against the Host header for mtls connections only' do
-      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
-      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+    it 'disables domain fronting by checking SNI against the Host header for mtls connections only' do
+      expect(frontend_https).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_https).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_https).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match')
     end
   end

--- a/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_wss_spec.rb
@@ -89,9 +89,9 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       default_properties.merge({ 'disable_domain_fronting' => true })
     end
 
-    it 'disables domain fronting by checkig SNI against the Host header' do
-      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
-      expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+    it 'disables domain fronting by checking SNI against the Host header' do
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_wss).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } !ssl_sni_http_host_match')
     end
   end
@@ -101,9 +101,9 @@ describe 'config/haproxy.config HTTPS Websockets frontend' do
       default_properties.merge({ 'disable_domain_fronting' => 'mtls_only' })
     end
 
-    it 'disables domain fronting by checkig SNI against the Host header for mtls connections only' do
-      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:)')
-      expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,strcmp(txn.host) eq 0')
+    it 'disables domain fronting by checking SNI against the Host header for mtls connections only' do
+      expect(frontend_wss).to include('http-request set-var(txn.host) hdr(host),field(1,:),lower')
+      expect(frontend_wss).to include('acl ssl_sni_http_host_match ssl_fc_sni,lower,strcmp(txn.host) eq 0')
       expect(frontend_wss).to include('http-request deny deny_status 421 if { ssl_fc_has_sni } { ssl_c_used } !ssl_sni_http_host_match')
     end
   end


### PR DESCRIPTION
Host header and SNI case should be ignored when checking for domain fronting

Also fixes acceptance test config parsing error checking