### PR TITLE
add support for TLSv1.3 ciphersuites

### DIFF
--- a/acceptance-tests/https_frontend_test.go
+++ b/acceptance-tests/https_frontend_test.go
@@ -93,9 +93,25 @@ var _ = Describe("HTTPS Frontend", func() {
 		}
 	})
 
-	It("Correctly proxies HTTPS requests", func() {
-		By("Sending a request to HAProxy using HTTP 1.1")
+	It("Correctly proxies HTTPS requests with TLSv1.2 and 1.3", func() {
+		By("Sending a request to HAProxy using HTTP 1.1 and TLSv1.2")
+
+		http1Client.Transport.(*http.Transport).TLSClientConfig.MaxVersion = tls.VersionTLS12
+		http1Client.Transport.(*http.Transport).TLSClientConfig.MinVersion = tls.VersionTLS12
+
 		resp, err := http1Client.Get("https://haproxy.internal:443")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.ProtoMajor).To(Equal(1))
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Eventually(gbytes.BufferReader(resp.Body)).Should(gbytes.Say("Hello cloud foundry"))
+
+		By("Sending a request to HAProxy using HTTP 1.1 and TLSv1.3")
+
+		http1Client.Transport.(*http.Transport).TLSClientConfig.MaxVersion = tls.VersionTLS13
+		http1Client.Transport.(*http.Transport).TLSClientConfig.MinVersion = tls.VersionTLS13
+
+		resp, err = http1Client.Get("https://haproxy.internal:443")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.ProtoMajor).To(Equal(1))
 

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -110,6 +110,7 @@ properties:
       - 'client_ca_file' (replaces ha_proxy.client_ca_file)
       - 'verify' (allowed values: [none|optional|required])
       - 'ssl_ciphers' (overrides ha_proxy.ssl_ciphers)
+      - 'ssl_ciphersuites' (overrides ha_proxy.ssl_ciphersuites)
       - 'ssl_min_version' (allowed values: [SSLv3 | TLSv1.0 | TLSv1.1 | TLSv1.2 | TLSv1.3])
       - 'ssl_max_version' (allowed values: [SSLv3 | TLSv1.0 | TLSv1.1 | TLSv1.2 | TLSv1.3])
       - 'client_revocation_list' (replaces ha_proxy.client_revocation_list)
@@ -141,6 +142,7 @@ properties:
           -----END CERTIFICATE-----
         verify: required
         ssl_ciphers: AES:ALL:!aNULL:!eNULL:+RC4:@STRENGTH
+        ssl_ciphersuites: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
         ssl_min_version: TLSv1.2
         ssl_max_version: TLSv1.3
         client_revocation_list: |
@@ -205,7 +207,10 @@ properties:
     default: false
   ha_proxy.ssl_ciphers:
     default: ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
-    description: "List of SSL Ciphers that are passed to HAProxy"
+    description: "List of TLSv<=1.2 Ciphers for that are passed to HAProxy"
+  ha_proxy.ssl_chiphersuites:
+    default: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    description: "List of TLSv1.3 Ciphers that are passed to HAProxy"
   ha_proxy.hsts_enable:
     default: false
     description: "Enables HSTS(Strict-Transport-Security Header) for all the SSL/TLS listeners"

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -44,6 +44,9 @@ if_p("ha_proxy.crt_list") do |crt_list|
     if list_entry.key?("ssl_ciphers")
       sslbindconf += " ciphers " + list_entry["ssl_ciphers"]
     end
+    if list_entry.key?("ssl_ciphersuites")
+      sslbindconf += " ciphersuites " + list_entry["ssl_ciphersuites"]
+    end
     if list_entry.key?("ssl_min_version")
       sslbindconf += " ssl-min-ver " + list_entry["ssl_min_version"]
     end

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -215,8 +215,10 @@ global
     stats timeout 2m
     ssl-default-bind-options <%= ssl_flags %>
     ssl-default-bind-ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    ssl-default-bind-ciphersuites <%= p("ha_proxy.ssl_chiphersuites") %>
     ssl-default-server-options <%= ssl_flags %>
     ssl-default-server-ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    ssl-default-server-ciphersuites <%= p("ha_proxy.ssl_chiphersuites") %>
 
 defaults
     log global

--- a/spec/haproxy/templates/certs.ttar_spec.rb
+++ b/spec/haproxy/templates/certs.ttar_spec.rb
@@ -322,6 +322,28 @@ describe 'config/certs.ttar' do
         EXPECTED
       end
     end
+
+    describe 'ha_proxy.crt_list[].ssl_ciphersuites' do
+      let(:ttar) do
+        template.render({
+          'ha_proxy' => {
+            'crt_list' => [{
+              'ssl_ciphersuites' => 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384',
+              'ssl_pem' => 'ssl_pem contents'
+            }]
+          }
+        })
+      end
+
+      it 'is included in the crt list' do
+        expect(ttar_entry(ttar, '/var/vcap/jobs/haproxy/config/ssl/crt-list')).to eq(<<~EXPECTED)
+
+          /var/vcap/jobs/haproxy/config/ssl/cert-0.pem [ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384]
+
+
+        EXPECTED
+      end
+    end
   end
 
   describe 'ha_proxy.crt_list[].ssl_min_version' do

--- a/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/global_and_default_options_spec.rb
@@ -244,6 +244,19 @@ describe 'config/haproxy.config global and default options' do
     end
   end
 
+  context 'when ha_proxy.ssl_chiphersuites is provided' do
+    let(:properties) do
+      {
+        'ssl_chiphersuites' => 'TLS_AES_128_GCM_SHA256'
+      }
+    end
+
+    it 'overrides the allowed ciphers' do
+      expect(global).to include('ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256')
+      expect(global).to include('ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256')
+    end
+  end
+
   context 'when ha_proxy.max_connections is provided' do
     let(:properties) do
       {


### PR DESCRIPTION
added fields:
- ha_proxy.ssl_ciphersuites sets ssl-default-bind-ciphersuites
  and ssl-default-server-ciphersuites
- ha_proxy.crt_list[].ssl_ciphersuites sets the corresponding
  fields in the CRT list