### PR TITLE
Added flag to separate monit healthchecks

### DIFF
--- a/jobs/haproxy/monit
+++ b/jobs/haproxy/monit
@@ -11,7 +11,7 @@ if p("ha_proxy.ext_crt_list") then
 end
 -%>
 
-<%- if p("ha_proxy.enable_health_check_http") -%>
+<%- if p("ha_proxy.enable_monit_health_check_http") -%>
 check host haproxy-health address localhost
   depends on haproxy
   if failed host localhost port <%= p("ha_proxy.health_check_port") -%> protocol http

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -190,6 +190,9 @@ properties:
   ha_proxy.enable_health_check_http:
     description: "Optionally enable http health-check on `haproxy_ip:8080/health`. It shows `200 OK` if >0 backend servers are up. If used with ext_crt_list_timeout you should make sure that the deployment canary_watch_time and update_watch_time are configured to wait at least the number of seconds defined by ext_crt_list_timeout."
     default: false
+  ha_proxy.enable_monit_health_check_http:
+    description: "Optionally enable http health-check on `haproxy_ip:8080/health` using monit."
+    default: false
   ha_proxy.health_check_port:
     description: "port for http health-check"
     default: 8080


### PR DESCRIPTION
Added a flat to separate monit health checks configuration from the other
health checks, thus enabling us to test the platform on the cases that we
are starting up the foundation.

This flag is added to enable compatibility after the new monit health checks were enabled on version 10.5.0

Jhonathan Aristizabal <jhonathana@vmware.com>