### PR TITLE
temporarily use latest concourse/github-release-resource resource until Concourse is updated to 7.5.0+

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -399,6 +399,15 @@ resource_types:
     source:
       repository: teliaoss/github-pr-resource
 
+  # FIXME: Need to use latest version of this resource due to
+  # https://github.com/concourse/github-release-resource/issues/108
+  # https://github.com/concourse/github-release-resource/pull/107
+  # Until Concourse is updated to 7.5.0+
+  - name: github-release-alt
+    type: registry-image
+    source:
+      repository: concourse/github-release-resource
+
 resources:
   - name: git
     type: git
@@ -447,7 +456,7 @@ resources:
       url: ((slack.webhook))
 
   - name: github
-    type: github-release
+    type: github-release-alt
     source:
       user:         cloudfoundry-incubator
       repository:   haproxy-boshrelease


### PR DESCRIPTION
Concourse github resource is broken due to:
https://github.com/concourse/github-release-resource/issues/108
https://github.com/concourse/github-release-resource/pull/107

This PR implements this fix https://github.com/concourse/github-release-resource/pull/107#issuecomment-919194641 until we get around to updating Concourse to 7.5.0+