### PR TITLE
Fix SHA1 of haproxy release

### DIFF
--- a/manifests/haproxy.yml
+++ b/manifests/haproxy.yml
@@ -42,4 +42,4 @@ releases:
 - name: haproxy
   version: 11.4.4
   url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v11.4.4/haproxy-11.4.4.tgz
-  sha1: f70bff045923cce809260fdd20d1352f0dce8d5a
+  sha1: 94b2b3570c3e7900c67bb1c30f7eaa1fe6fb11e0


### PR DESCRIPTION
Hello maintainer team,

when we tried deploying HAproxy we got the error: 
 Error: Expected stream to have digest 'f70bff045923cce809260fdd20d1352f0dce8d5a' but was '94b2b3570c3e7900c67bb1c30f7eaa1fe6fb11e0'
When I checked BOSH, it also said 
https://bosh.io/releases/github.com/cloudfoundry-community/haproxy-boshrelease?all=1 that 9b4 is the right digest. This PR is to fix this in the sample manifest so it can be deployed again.

