### PR TITLE
Retain True-Client-Ip for Route Services

### DIFF
--- a/acceptance-tests/true_client_ip_test.go
+++ b/acceptance-tests/true_client_ip_test.go
@@ -1,0 +1,440 @@
+package acceptance_tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("True Client IP - forward_only_if_route_service", func() {
+	opsfileHeaders := `---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/true_client_ip_header?
+  value: "X-CF-True-Client-IP"
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/forward_true_client_ip_header?
+  value: "forward_only_if_route_service"
+# Configure CA and cert chain
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
+  value:
+    snifilter:
+    - haproxy.internal
+    ssl_pem:
+      cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
+      private_key: ((https_frontend.private_key))
+# Declare certs
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend
+    type: certificate
+    options:
+      ca: https_frontend_ca
+      common_name: haproxy.internal
+      alternative_names: [haproxy.internal]
+`
+	var closeLocalServer func()
+	var closeTunnel func()
+	var creds struct {
+		HTTPSFrontend struct {
+			Certificate string `yaml:"certificate"`
+			PrivateKey  string `yaml:"private_key"`
+			CA          string `yaml:"ca"`
+		} `yaml:"https_frontend"`
+	}
+	var client *http.Client
+	var recordedHeaders http.Header
+	var request *http.Request
+	var err error
+
+	BeforeEach(func() {
+		haproxyBackendPort := 12000
+		var varsStoreReader varsStoreReader
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileHeaders}, map[string]interface{}{}, true)
+
+		err = varsStoreReader(&creds)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Starting a local http server to act as a backend")
+		var localPort int
+		closeLocalServer, localPort, err = startLocalHTTPServer(nil, func(w http.ResponseWriter, r *http.Request) {
+			writeLog("Backend server handling incoming request")
+			recordedHeaders = r.Header
+			_, _ = w.Write([]byte("OK"))
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		closeTunnel = setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		client = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
+			[]tls.Certificate{}, "",
+		)
+	})
+
+	AfterEach(func() {
+		closeLocalServer()
+		closeTunnel()
+	})
+
+	It("Adds a header with the provided name and correct value for the true client ip, if it doesn't exist", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly sets the True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+
+	It("Overwrites the True-Client-Ip header if it is already set AND the request is not a route-service", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Overwrites the existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+
+	It("Does not overwrite the True-Client-Ip header if it is already set AND the request is a route-service", func() {
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		// Mock a route-service request via the X-Cf-Proxy-Signature header
+		request.Header.Set("X-Cf-Proxy-Signature", "abc123")
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly preserves the pre-existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(recordedHeaders[headerKey][0]).To(Equal("8.8.8.8"))
+	})
+})
+
+var _ = Describe("True Client IP - always_forward", func() {
+	opsfileHeaders := `---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/true_client_ip_header?
+  value: "X-CF-True-Client-IP"
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/forward_true_client_ip_header?
+  value: "always_forward"
+# Configure CA and cert chain
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
+  value:
+    snifilter:
+    - haproxy.internal
+    ssl_pem:
+      cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
+      private_key: ((https_frontend.private_key))
+# Declare certs
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend
+    type: certificate
+    options:
+      ca: https_frontend_ca
+      common_name: haproxy.internal
+      alternative_names: [haproxy.internal]
+`
+	var closeLocalServer func()
+	var closeTunnel func()
+	var creds struct {
+		HTTPSFrontend struct {
+			Certificate string `yaml:"certificate"`
+			PrivateKey  string `yaml:"private_key"`
+			CA          string `yaml:"ca"`
+		} `yaml:"https_frontend"`
+	}
+	var client *http.Client
+	var recordedHeaders http.Header
+	var request *http.Request
+	var err error
+
+	BeforeEach(func() {
+		haproxyBackendPort := 12000
+		var varsStoreReader varsStoreReader
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileHeaders}, map[string]interface{}{}, true)
+
+		err = varsStoreReader(&creds)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Starting a local http server to act as a backend")
+		var localPort int
+		closeLocalServer, localPort, err = startLocalHTTPServer(nil, func(w http.ResponseWriter, r *http.Request) {
+			writeLog("Backend server handling incoming request")
+			recordedHeaders = r.Header
+			_, _ = w.Write([]byte("OK"))
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		closeTunnel = setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		client = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
+			[]tls.Certificate{}, "",
+		)
+	})
+
+	AfterEach(func() {
+		closeLocalServer()
+		closeTunnel()
+	})
+
+	It("Adds a header with the provided name and correct value for the true client ip, if it doesn't exist", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly sets the True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+
+	It("Does not overwrite the True-Client-Ip header if it is already set AND the request is not a route-service", func() {
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly preserves the pre-existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(recordedHeaders[headerKey][0]).To(Equal("8.8.8.8"))
+	})
+
+	It("Does not overwrite the True-Client-Ip header if it is already set AND the request is a route-service", func() {
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		// Mock a route-service request via the X-Cf-Proxy-Signature header
+		request.Header.Set("X-Cf-Proxy-Signature", "abc123")
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly preserves the pre-existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(recordedHeaders[headerKey][0]).To(Equal("8.8.8.8"))
+	})
+})
+
+var _ = Describe("True Client IP - always_set", func() {
+	opsfileHeaders := `---
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/true_client_ip_header?
+  value: "X-CF-True-Client-IP"
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/forward_true_client_ip_header?
+  value: "always_set"
+# Configure CA and cert chain
+- type: replace
+  path: /instance_groups/name=haproxy/jobs/name=haproxy/properties/ha_proxy/crt_list?/-
+  value:
+    snifilter:
+    - haproxy.internal
+    ssl_pem:
+      cert_chain: ((https_frontend.certificate))((https_frontend_ca.certificate))
+      private_key: ((https_frontend.private_key))
+# Declare certs
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: bosh
+- type: replace
+  path: /variables?/-
+  value:
+    name: https_frontend
+    type: certificate
+    options:
+      ca: https_frontend_ca
+      common_name: haproxy.internal
+      alternative_names: [haproxy.internal]
+`
+	var closeLocalServer func()
+	var closeTunnel func()
+	var creds struct {
+		HTTPSFrontend struct {
+			Certificate string `yaml:"certificate"`
+			PrivateKey  string `yaml:"private_key"`
+			CA          string `yaml:"ca"`
+		} `yaml:"https_frontend"`
+	}
+	var client *http.Client
+	var recordedHeaders http.Header
+	var request *http.Request
+	var err error
+
+	BeforeEach(func() {
+		haproxyBackendPort := 12000
+		var varsStoreReader varsStoreReader
+		haproxyInfo, varsStoreReader := deployHAProxy(baseManifestVars{
+			haproxyBackendPort:    haproxyBackendPort,
+			haproxyBackendServers: []string{"127.0.0.1"},
+			deploymentName:        deploymentNameForTestNode(),
+		}, []string{opsfileHeaders}, map[string]interface{}{}, true)
+
+		err = varsStoreReader(&creds)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Starting a local http server to act as a backend")
+		var localPort int
+		closeLocalServer, localPort, err = startLocalHTTPServer(nil, func(w http.ResponseWriter, r *http.Request) {
+			writeLog("Backend server handling incoming request")
+			recordedHeaders = r.Header
+			_, _ = w.Write([]byte("OK"))
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		closeTunnel = setupTunnelFromHaproxyToTestServer(haproxyInfo, haproxyBackendPort, localPort)
+		client = buildHTTPClient(
+			[]string{creds.HTTPSFrontend.CA},
+			map[string]string{"haproxy.internal:443": fmt.Sprintf("%s:443", haproxyInfo.PublicIP)},
+			[]tls.Certificate{}, "",
+		)
+	})
+
+	AfterEach(func() {
+		closeLocalServer()
+		closeTunnel()
+	})
+
+	It("Adds a header with the provided name and correct value for the true client ip, if it doesn't exist", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly sets the True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+
+	It("Overwrites the True-Client-Ip header if it is already set AND the request is not a route-service", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly preserves the pre-existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+
+	It("Overwrites the True-Client-Ip header if it is already set AND the request is a route-service", func() {
+		ipAddresses := getAllIpAddresses()
+		request, err = http.NewRequest("GET", "https://haproxy.internal:443", nil)
+		// Mock a route-service request via the X-Cf-Proxy-Signature header
+		request.Header.Set("X-Cf-Proxy-Signature", "abc123")
+		request.Header.Set("X-Cf-True-Client-Ip", "8.8.8.8")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Correctly preserves the pre-existing True-Client-Ip Header")
+		resp, err := client.Do(request)
+		expect200(resp, err)
+		headerKey := "X-Cf-True-Client-Ip"
+		Expect(recordedHeaders).To(HaveKey(headerKey))
+		Expect(recordedHeaders[headerKey]).To(HaveLen(1))
+		Expect(ipAddresses).To(ContainElement(recordedHeaders[headerKey][0]))
+	})
+})
+
+func getAllIpAddresses() (ips []string) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		fmt.Printf("Cannot get interface: %s", err)
+		return
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			fmt.Printf("Cannot get addresses for interface %s: %s", iface.Name, err)
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			default:
+				continue
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+
+			ips = append(ips, ip.String())
+		}
+	}
+	return ips
+}

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -406,7 +406,21 @@ properties:
         MyCustomHeader: 3
 
   ha_proxy.true_client_ip_header:
-    description: "Header to use to store the client's IP address, as seen from HAProxy. The header will be overwritten if it already exists in the request."
+    description: "Header to use to store the client's IP address, as seen from HAProxy. See forward_true_client_ip_header for more options."
+
+  ha_proxy.forward_true_client_ip_header:
+    description: |
+      This option lets you decide how to handle the header specified in ha_proxy.true_client_ip_header on any http and https frontend, when it already present in the request.
+      Your options are:
+      
+      - always_forward: Always preserve the existing header.
+      
+      - forward_only_if_route_service: This option is useful to support the header with Route Services.
+          The header will be overwritten with the current source address, unless there is an X-Cf-Proxy-Signature header.
+      
+      - overwrite: Always overwrite the header with the current source address. 
+
+    default: forward_only_if_route_service
 
   ha_proxy.backend_crt:
     description: "Provides client certificate to backend server to do mutual ssl. Note this only configures the client cert for HTTP backends configured via the backend_servers property or through BOSH links. It is not used with backend servers configured via routed_backend_servers or TCP backends"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -418,7 +418,7 @@ properties:
       - forward_only_if_route_service: This option is useful to support the header with Route Services.
           The header will be overwritten with the current source address, unless there is an X-Cf-Proxy-Signature header.
       
-      - overwrite: Always overwrite the header with the current source address. 
+      - always_set: Always set the header with the current source address. Will overwrite any existing header.
 
     default: forward_only_if_route_service
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -146,6 +146,22 @@ else
   abort("Unknown 'forwarded_client_cert' option: #{forwarded_client_cert_option}. Known options: 'always_forward_only', 'forward_only', 'sanitize_set', 'forward_only_if_route_service'")
 end
 
+forward_true_client_ip_header = :forward_only_if_route_service
+if_p("ha_proxy.true_client_ip_header") do
+  if_p("ha_proxy.forward_true_client_ip_header") do
+    case p("ha_proxy.forward_true_client_ip_header").downcase
+      when "always_forward"
+        forward_true_client_ip_header = :always_forward
+      when "forward_only_if_route_service"
+        forward_true_client_ip_header = :forward_only_if_route_service
+      when "overwrite"
+        forward_true_client_ip_header = :overwrite
+      else
+        abort("Unknown 'forward_true_client_ip_header' option: #{forward_true_client_ip_header}. Known options: 'always_forward', 'forward_only_if_route_service', 'overwrite'")
+      end
+  end
+end
+
 disable_domain_fronting = p("ha_proxy.disable_domain_fronting")
 if ![true, false, "true", "false", "mtls_only"].include?(disable_domain_fronting)
   abort("Unknown 'disable_domain_fronting' option: #{disable_domain_fronting}. Known options: true, false or 'mtls_only'")
@@ -516,6 +532,8 @@ frontend http-in
 frontend https-in
     mode http
     bind <%= p("ha_proxy.binding_ip") %>:443 <%= accept_proxy %> <%= tls_bind_options %> <%= v4v6 %> <%= default_alpn_config %>
+    # Set this acl when the request is a route service request, used by ha_proxy.forward_true_client_ip_header and ha_proxy.forwarded_client_cert
+    acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
   <%- if disable_domain_fronting -%>
     # Check whether the client is attempting domain fronting.
     # Ensure a host header exists to check against
@@ -587,7 +605,6 @@ frontend https-in
     http-request del-header X-SSL-Client-NotAfter   if ! { ssl_c_used }
     http-request del-header X-SSL-Client-Root-CA-DN if ! { ssl_c_used }
   <%- when :non_route_service_only -%>
-    acl route_service_request hdr(X-Cf-Proxy-Signature) -m found
     http-request del-header X-Forwarded-Client-Cert if !route_service_request
     http-request del-header X-SSL-Client            if !route_service_request
     http-request del-header X-SSL-Client-Session-ID if !route_service_request
@@ -655,7 +672,18 @@ frontend https-in
     <%- end -%>
   <%- end -%>
   <%- if_p("ha_proxy.true_client_ip_header") do |header| -%>
-    http-request set-header <%= header %> %[src]
+    <%- case forward_true_client_ip_header -%>
+    <%- when  :always_forward -%>
+      # only set the header if it is not already set
+      acl true_client_ip_request hdr(<%= header %>) -m found
+      http-request set-header <%= header %> %[src] if !true_client_ip_request
+    <%- when  :overwrite -%>
+      # always set header
+      http-request set-header <%= header %> %[src]
+    <%- when  :forward_only_if_route_service -%>
+      acl true_client_ip_request hdr(<%= header %>) -m found
+      http-request set-header <%= header %> %[src] if !true_client_ip_request or route_service_request
+    <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>
     acl private src -f /var/vcap/jobs/haproxy/config/trusted_domain_cidrs.txt

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -682,7 +682,7 @@ frontend https-in
       http-request set-header <%= header %> %[src]
     <%- when  :forward_only_if_route_service -%>
       acl true_client_ip_request hdr(<%= header %>) -m found
-      http-request set-header <%= header %> %[src] if !true_client_ip_request or route_service_request
+      http-request set-header <%= header %> %[src] unless true_client_ip_request && route_service_request
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -154,10 +154,10 @@ if_p("ha_proxy.true_client_ip_header") do
         forward_true_client_ip_header = :always_forward
       when "forward_only_if_route_service"
         forward_true_client_ip_header = :forward_only_if_route_service
-      when "overwrite"
-        forward_true_client_ip_header = :overwrite
+      when "always_set"
+        forward_true_client_ip_header = :always_set
       else
-        abort("Unknown 'forward_true_client_ip_header' option: #{forward_true_client_ip_header}. Known options: 'always_forward', 'forward_only_if_route_service', 'overwrite'")
+        abort("Unknown 'forward_true_client_ip_header' option: #{forward_true_client_ip_header}. Known options: 'always_forward', 'forward_only_if_route_service', 'always_set'")
       end
   end
 end
@@ -674,15 +674,15 @@ frontend https-in
   <%- if_p("ha_proxy.true_client_ip_header") do |header| -%>
     <%- case forward_true_client_ip_header -%>
     <%- when  :always_forward -%>
-      # only set the header if it is not already set
-      acl true_client_ip_request hdr(<%= header %>) -m found
-      http-request set-header <%= header %> %[src] if !true_client_ip_request
-    <%- when  :overwrite -%>
-      # always set header
-      http-request set-header <%= header %> %[src]
+    # only set the header if it is not already set
+    acl true_client_ip_found hdr(<%= header %>) -m found
+    http-request set-header <%= header %> %[src] if !true_client_ip_found
+    <%- when  :always_set -%>
+    # always set header
+    http-request set-header <%= header %> %[src]
     <%- when  :forward_only_if_route_service -%>
-      acl true_client_ip_request hdr(<%= header %>) -m found
-      http-request set-header <%= header %> %[src] unless true_client_ip_request route_service_request
+    acl true_client_ip_found hdr(<%= header %>) -m found
+    http-request set-header <%= header %> %[src] unless true_client_ip_found route_service_request
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -682,7 +682,7 @@ frontend https-in
       http-request set-header <%= header %> %[src]
     <%- when  :forward_only_if_route_service -%>
       acl true_client_ip_request hdr(<%= header %>) -m found
-      http-request set-header <%= header %> %[src] unless true_client_ip_request && route_service_request
+      http-request set-header <%= header %> %[src] unless true_client_ip_request route_service_request
     <%- end -%>
   <%- end -%>
   <%- if p("ha_proxy.internal_only_domains").size > 0 -%>

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -717,7 +717,6 @@ describe 'config/haproxy.config HTTPS frontend' do
         end.to raise_error(/Unknown 'forward_true_client_ip_header' option: forward_only_if_route_service. Known options: 'always_forward', 'forward_only_if_route_service', 'always_set'/)
       end
     end
-
   end
 
   context 'when ha_proxy.enable_http2 is true' do

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -664,11 +664,11 @@ describe 'config/haproxy.config HTTPS frontend' do
   end
 
   context 'when ha_proxy.true_client_ip_header is set' do
-    context 'when ha_proxy.forward_true_client_ip_header is set to overwrite' do
+    context 'when ha_proxy.forward_true_client_ip_header is set to always_set' do
       let(:properties) do
         default_properties.merge({
           'true_client_ip_header' => 'X-CF-True-Client-IP',
-          'forward_true_client_ip_header' => 'overwrite'
+          'forward_true_client_ip_header' => 'always_set'
         })
       end
 
@@ -686,7 +686,7 @@ describe 'config/haproxy.config HTTPS frontend' do
       end
 
       it 'adds the X-CF-True-Client-IP header' do
-        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] if !true_client_ip_request')
+        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] if !true_client_ip_found')
       end
     end
 
@@ -699,7 +699,7 @@ describe 'config/haproxy.config HTTPS frontend' do
       end
 
       it 'adds the X-CF-True-Client-IP header' do
-        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] unless true_client_ip_request route_service_request')
+        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] unless true_client_ip_found route_service_request')
       end
     end
 
@@ -714,7 +714,7 @@ describe 'config/haproxy.config HTTPS frontend' do
       it 'aborts with a meaningful error message' do
         expect do
           frontend_https
-        end.to raise_error(/Unknown 'forward_true_client_ip_header' option: forward_only_if_route_service. Known options: 'always_forward', 'forward_only_if_route_service', 'overwrite'/)
+        end.to raise_error(/Unknown 'forward_true_client_ip_header' option: forward_only_if_route_service. Known options: 'always_forward', 'forward_only_if_route_service', 'always_set'/)
       end
     end
 

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -664,12 +664,30 @@ describe 'config/haproxy.config HTTPS frontend' do
   end
 
   context 'when ha_proxy.true_client_ip_header is set' do
-    let(:properties) do
-      default_properties.merge({ 'true_client_ip_header' => 'X-CF-True-Client-IP' })
+    context 'when forward_true_client_ip_header is set to overwrite' do
+      let(:properties) do
+        default_properties.merge({
+          'true_client_ip_header' => 'X-CF-True-Client-IP',
+          'forward_true_client_ip_header' => 'overwrite'
+        })
+      end
+
+      it 'adds the X-CF-True-Client-IP header' do
+        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src]')
+      end
     end
 
-    it 'adds the X-CF-True-Client-IP header' do
-      expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src]')
+    context 'when forward_true_client_ip_header is set to always_forward' do
+      let(:properties) do
+        default_properties.merge({
+          'true_client_ip_header' => 'X-CF-True-Client-IP',
+          'forward_true_client_ip_header' => 'always_forward'
+        })
+      end
+
+      it 'adds the X-CF-True-Client-IP header' do
+        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] if !true_client_ip_request')
+      end
     end
   end
 

--- a/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/frontend_https_spec.rb
@@ -664,7 +664,7 @@ describe 'config/haproxy.config HTTPS frontend' do
   end
 
   context 'when ha_proxy.true_client_ip_header is set' do
-    context 'when forward_true_client_ip_header is set to overwrite' do
+    context 'when ha_proxy.forward_true_client_ip_header is set to overwrite' do
       let(:properties) do
         default_properties.merge({
           'true_client_ip_header' => 'X-CF-True-Client-IP',
@@ -677,7 +677,7 @@ describe 'config/haproxy.config HTTPS frontend' do
       end
     end
 
-    context 'when forward_true_client_ip_header is set to always_forward' do
+    context 'when ha_proxy.forward_true_client_ip_header is set to always_forward' do
       let(:properties) do
         default_properties.merge({
           'true_client_ip_header' => 'X-CF-True-Client-IP',
@@ -689,6 +689,35 @@ describe 'config/haproxy.config HTTPS frontend' do
         expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] if !true_client_ip_request')
       end
     end
+
+    context 'when ha_proxy.forward_true_client_ip_header is set to forward_only_if_route_service' do
+      let(:properties) do
+        default_properties.merge({
+          'true_client_ip_header' => 'X-CF-True-Client-IP',
+          'forward_true_client_ip_header' => 'forward_only_if_route_service'
+        })
+      end
+
+      it 'adds the X-CF-True-Client-IP header' do
+        expect(frontend_https).to include('http-request set-header X-CF-True-Client-IP %[src] unless true_client_ip_request route_service_request')
+      end
+    end
+
+    context 'when ha_proxy.forward_true_client_ip_header is set to an invalid value' do
+      let(:properties) do
+        default_properties.merge({
+          'true_client_ip_header' => 'X-CF-True-Client-IP',
+          'forward_true_client_ip_header' => 'pineapple'
+        })
+      end
+
+      it 'aborts with a meaningful error message' do
+        expect do
+          frontend_https
+        end.to raise_error(/Unknown 'forward_true_client_ip_header' option: forward_only_if_route_service. Known options: 'always_forward', 'forward_only_if_route_service', 'overwrite'/)
+      end
+    end
+
   end
 
   context 'when ha_proxy.enable_http2 is true' do


### PR DESCRIPTION
This Pull-Request completes the True-Client-Ip feature introduced with #759. With this change, we add three options to deal with the header: 
* `forward_only_if_route_service`: Forward only in route service scenario. This is the default behavior which adds support for the True-Client-Ip header in the route service scenario.
* `always_set`: Always set the header, overwrite if existing.
* `always_forward`: Always forward if existing, set otherwise.