### PR TITLE
feat: Environment variable override for HAProxy Wrapper

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -100,6 +100,12 @@ properties:
       Example
         curl -H "Host: bob.com" https://alice.com    <-- This will result in a 421 Misdirected Request
     default: false
+  ha_proxy.env_override:
+    description: |
+      Environment variables to be set ad-hoc when the HAProxy process is started. This can be used to override various settings for HAProxy and Linux process level.
+    example:
+       env_override: "LD_PRELOAD=/var/vcap/packages/haproxy/lib/libjemalloc.so.2"
+    default: ~
   ha_proxy.ssl_pem:
     description: |
       Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'cert_chain' and 'private_key',

--- a/jobs/haproxy/templates/haproxy_wrapper.erb
+++ b/jobs/haproxy/templates/haproxy_wrapper.erb
@@ -8,6 +8,8 @@ CONFIG=/var/vcap/jobs/haproxy/config/haproxy.config
 PID_FILE=/var/vcap/sys/run/haproxy/haproxy.pid
 DRAIN_LOCK=/var/vcap/sys/run/haproxy/drain.lock
 
+ENV_OVERRIDE=<$= p("ha_proxy.env_override", "") %>
+
 cleanup_daemon() {
   if [ -f ${PID_FILE} ]; then
     pkill -F ${PID_FILE} || true
@@ -105,7 +107,7 @@ trap reload_daemon USR2
 
 # Start up
 echo "$(date): Starting HAProxy"
-haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
+$ENV_OVERRIDE haproxy -f ${CONFIG} -W -p ${PID_FILE} <%= flags.join(' ') %> <%= cat_pipe %>
 
 # wait for the HAProxy main process to terminate non-gracefully (drain)
 while [ -f ${DRAIN_LOCK} ] || kill -0 $(cat ${PID_FILE}) 2>/dev/null; do sleep 1; done;


### PR DESCRIPTION
The HAProxy Wrapper starts the `haproxy` process.

Setting the config property `haproxy.env_override` allows declaring ad-hoc environment variables for the `haproxy` process call.

This allows overriding environment variables for testing and experimentation.
