### PR TITLE
Use the correct python binary from venv

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -330,7 +330,7 @@ jobs:
               platform: linux
               run:
                 dir: git
-                path: /usr/bin/python3
+                path: /opt/venv/bin/python3
                 args: ["ci/scripts/autobump-dependencies.py"]
               params:
                 PR_BASE: master


### PR DESCRIPTION
Now python requirements are installed in python environment  so we should use the right interpreter which has the installed libraries