### PR TITLE
Revert HAProxy to 3.2.13

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.15.tar.gz:
-  size: 5141171
-  object_id: f9a682cd-03fa-47eb-745b-54f39e56ed6b
-  sha: sha256:117e408aff544c9ad758c2fb3fd8cf791a72609d3ae319b2cf9f2a0b035393c2
+haproxy/haproxy-3.2.13.tar.gz:
+  size: 5131384
+  object_id: cb8c1ad7-7135-404c-6104-b24cb13c9f54
+  sha: sha256:9cf45dadca6899908049d4c098d29ad866d89ba8a283d78a9c10890e157f6185
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.1  # http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz
 
-HAPROXY_VERSION=3.2.15  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.15.tar.gz
+HAPROXY_VERSION=3.2.13  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.13.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION
Due to a bug in HAProxy 3.2.14 and 3.2.15 (https://github.com/haproxy/haproxy/issues/3337) that results in frequent crashes  of HAProxy, an haproxy-boshrelease with the latest bosh-release changes and an unaffected HAProxy version is required.  