### PR TITLE
Bump haproxy version to 3.2.15

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.13.tar.gz:
-  size: 5131384
-  object_id: cb8c1ad7-7135-404c-6104-b24cb13c9f54
-  sha: sha256:9cf45dadca6899908049d4c098d29ad866d89ba8a283d78a9c10890e157f6185
+haproxy/haproxy-3.2.15.tar.gz:
+  size: 5141171
+  object_id: 6681c2de-6d54-4c51-501f-51e7cbbf0257
+  sha: sha256:117e408aff544c9ad758c2fb3fd8cf791a72609d3ae319b2cf9f2a0b035393c2
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.1  # http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz
 
-HAPROXY_VERSION=3.2.13  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.13.tar.gz
+HAPROXY_VERSION=3.2.15  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.15.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.13 to version 3.2.15, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.15.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.15](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.15](https://www.haproxy.org/bugs/bugs-3.2.15.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.15 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.15%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.15 and 3.2.13</summary>

```
2026/03/19 : 3.2.15
    - BUG/MINOR: mworker: don't set the PROC_O_LEAVING flag on master process
    - BUG/MINOR: tcpcheck: Fix typo in error error message for `http-check expect`
    - BUG/MINOR: jws: fix memory leak in jws_b64_signature
    - DOC: configuration: http-check expect example typo
    - DOC/CLEANUP: config: update mentions of the old "Global parameters" section
    - BUG/MINOR: mworker: always stop the receiving listener
    - BUG/MINOR: memprof: avoid a small memory leak in "show profiling"
    - MINOR: tools: extend the pointer hashing code to ease manipulations
    - MINOR: memprof: attempt different retry slots for different hashes on collision
    - BUG/MINOR: mworker: only match worker processes when looking for unspawned proc
    - BUG/MINOR: mworker: fix typo &= instead of & in proc list serialization
    - BUG/MINOR: mworker: set a timeout on the worker socketpair read at startup
    - BUG/MINOR: mworker: avoid passing NULL version in proc list serialization
    - BUG/MINOR: sockpair: set FD_CLOEXEC on fd received via SCM_RIGHTS
    - BUG/MINOR: spoe: Properly switch SPOE filter to WAITING_ACK state
    - BUG/MEDIUM: spoe: Properly abort processing on client abort
    - BUG/MINOR: h2/h3: Only test number of trailers inserted in HTX message
    - MINOR: htx: Add function to truncate all blocks after a specific block
    - BUG/MINOR: h2/h3: Never insert partial headers/trailers in an HTX message
    - BUG/MINOR: http-ana: Swap L7 buffer with request buffer by hand
    - BUG/MINOR: proxy: do not forget to validate quic-initial rules
    - BUG/MINOR: stream: Fix crash in stream dump if the current rule has no keyword
    - BUG/MINOR: mjson: make mystrtod() length-aware to prevent out-of-bounds reads
    - BUG/MINOR: spoe: Fix condition to abort processing on client abort
    - BUILD: spoe: Remove unsused variable
    - DEV: gdb: add a utility to find the post-mortem address from a core
    - MINOR: tools: add a function to create a tar file header
    - MINOR: tools: add a function to load a file into a tar archive
    - MINOR: config: support explicit "on" and "off" for "set-dumpable"
    - MINOR: debug: read all libs in memory when set-dumpable=libs
    - DEV: gdb: add a new utility to extract libs from a core dump: libs-from-core
    - MINOR: debug: copy debug symbols from /usr/lib/debug when present
    - MINOR: debug: opportunistically load libthread_db.so.1 with set-dumpable=libs
    - BUG/MINOR: mworker: don't try to access an initializing process
    - BUG/MEDIUM: peers: enforce check on incoming table key type
    - BUG/MINOR: mux-h2: properly ignore R bit in GOAWAY stream ID
    - BUG/MINOR: mux-h2: properly ignore R bit in WINDOW_UPDATE increments
    - BUG/MAJOR: h3: check body size with content-length on empty FIN
    - BUG/MEDIUM: h3: reject unaligned frames except DATA
    - MINOR: mworker/cli: extract worker "show proc" row printer
    - BUG/MINOR: mworker/cli: fix show proc pagination losing entries on resume
    - CI: github: treat vX.Y.Z release tags as stable like haproxy-* branches

2026/03/09 : 3.2.14
    - MINOR: mux-h2: also count glitches on invalid trailers
    - MINOR: mux-h2: add a new setting, "tune.h2.log-errors" to tweak error logging
    - BUG/MEDIUM: mux-h2: make sure to always report pending errors to the stream
    - BUG/MINOR: promex: fix server iteration when last server is deleted
    - BUG/MEDIUM: stream: Handle TASK_WOKEN_RES as a stream event
    - BUG/MEDIUM: hpack: correctly deal with too large decoded numbers
    - BUG/MAJOR: qpack: unchecked length passed to huffman decoder
    - BUG/MINOR: qpack: fix 1-byte OOB read in qpack_decode_fs_pfx()
    - BUG/MEDIUM: qpack: correctly deal with too large decoded numbers
    - BUG/MINOR: h1-htx: Be sure that H1 response version starts by "HTTP/"
    - DEBUG: stream: Display the currently running rule in stream dump
    - MINOR: filters: Set last_entity when a filter fails on stream_start callback
    - BUG/MAJOR: fcgi: Fix param decoding by properly checking its size
    - BUG/MAJOR: resolvers: Properly lowered the names found in DNS response
    - BUG/MEDIUM: mux-fcgi: Use a safe loop to resume each stream eligible for sending
    - BUG/MINOR: ssl-sample: Fix sample_conv_sha2() by checking EVP_Digest* failures
    - BUG/MINOR: backend: Don't get proto to use for webscoket if there is no server
    - SCRIPTS: git-show-backports: hide the common ancestor warning in quiet mode
    - SCRIPTS: git-show-backports: add a restart-from-last option


```

</details>