### PR TITLE
fix: Prometheus Metrics endpoint is always enabled because ha_proxy.stats_promex_enable is not checked properly

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -362,7 +362,7 @@ listen stats
     acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
     http-request deny unless private
     mode http
-  <%- if_p("ha_proxy.stats_promex_enable") do -%>
+  <%- if p("ha_proxy.stats_promex_enable") -%>
     http-request use-service prometheus-exporter if { path <%= p("ha_proxy.stats_promex_path") %> }
   <%- end -%>
     stats enable

--- a/spec/haproxy/templates/haproxy_config/stats_listener_spec.rb
+++ b/spec/haproxy/templates/haproxy_config/stats_listener_spec.rb
@@ -44,6 +44,12 @@ describe 'config/haproxy.config stats listener' do
       end
     end
 
+    context 'when ha_proxy.stats_promex_enable is false (default)' do
+      it 'does not include a prometheus exporter endpoint' do
+        expect(stats_listener).not_to include(a_string_including('prometheus-exporter'))
+      end
+    end
+
     context 'when ha_proxy.trusted_stats_cidrs is set' do
       let(:properties) do
         default_properties.merge({ 'trusted_stats_cidrs' => '1.2.3.4/32' })


### PR DESCRIPTION
- `if_p` yields whenever a property has any value, including spec defaults — it does not check the boolean value
- `ha_proxy.stats_promex_enable` has `default: false` in the spec, so `if_p` was always yielding and the `prometheus-exporter` line was always written to the rendered config, even when the property was never set by the operator
- Fix: replace `if_p(...)` with `if p(...)` so the boolean is actually evaluated

This has been the case since the feature was introduced in https://github.com/cloudfoundry/haproxy-boshrelease/pull/536 so the prometheus metrics endpoint is currently active everywhere. Merging this PR would fix this but potentially break scenarios where people rely on it but haven't set the flag to `true`.

Resolves: https://github.com/cloudfoundry/haproxy-boshrelease/issues/922