### PR TITLE
Bump haproxy version to 3.2.16

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.13.tar.gz:
-  size: 5131384
-  object_id: cb8c1ad7-7135-404c-6104-b24cb13c9f54
-  sha: sha256:9cf45dadca6899908049d4c098d29ad866d89ba8a283d78a9c10890e157f6185
+haproxy/haproxy-3.2.16.tar.gz:
+  size: 5147998
+  object_id: bccfcb21-02a3-457a-5c19-7031edb8b38d
+  sha: sha256:2ed807f2a8742a4c1ec64906fe857bc53472d521aea8dcc453c82b8e5b1ecb02
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.1  # http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz
 
-HAPROXY_VERSION=3.2.13  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.13.tar.gz
+HAPROXY_VERSION=3.2.16  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.16.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.13 to version 3.2.16, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.16.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.16](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.16](https://www.haproxy.org/bugs/bugs-3.2.16.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.16 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.16%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.16 and 3.2.13</summary>

```
2026/04/23 : 3.2.16
    - BUG/MINOR: mworker: fix sort order of mworker_proc in 'show proc'
    - BUG/MINOR: sock: adjust accept() error messages for ENFILE and ENOMEM
    - BUG/MINOR: qpack: fix 62-bit overflow and 1-byte OOB reads in decoding
    - MEDIUM: sched: do not run a same task multiple times in series
    - MINOR: sched: do not requeue a tasklet into the current queue
    - MINOR: sched: do not punish self-waking tasklets anymore
    - MEDIUM: sched: do not punish self-waking tasklets if TASK_WOKEN_ANY
    - MEDIUM: sched: change scheduler budgets to lower TL_BULK
    - MINOR: mux-h2: assign a limited frames processing budget
    - BUILD: sched: fix leftover of debugging test in single-run changes
    - BUG/MEDIUM: acme: fix multiple resource leaks in acme_x509_req()
    - BUG/MINOR: acme: leak of ext_san upon insertion error
    - BUG/MINOR: acme: wrong error when checking for duplicate section
    - BUG/MINOR: acme/cli: wrong argument check in 'acme renew'
    - Revert "BUG/MEDIUM: mux-h2: make sure to always report pending errors to the stream"
    - DOC: config: Add missing 'status-code' param for 'http-check expect' directive
    - DOC: config: Reorder params for 'tcp-check expect' directive
    - BUG/MINOR: acme: acme_ctx_destroy() leaks auth->dns
    - BUG/MINOR: acme: wrong labels logic always memprintf errmsg
    - BUG/MINOR: acme: fix incorrect number of arguments allowed in config
    - BUG/MEDIUM: spoe: Acquire context buffer in applet before consuming a frame
    - MINOR: ncbmbuf: improve itbmap_next() code
    - BUG/MINOR: acme: free() DER buffer on a2base64url error path
    - BUG/MINOR: acme: replace atol with len-bounded __strl2uic() for retry-after
    - BUG/MINOR: acme/cli: fix argument check and error in 'acme challenge_ready'
    - BUILD: tools: potential null pointer dereference in dl_collect_libs_cb
    - BUG/MINOR: acme: permission checks on the CLI
    - BUG/MINOR: config: Properly test warnif_misplaced_* return values
    - BUG/MINOR: http-ana: Only consider client abort for abortonclose
    - BUG/MEDIUM: acme: skip doing challenge if it is already valid
    - BUG/MINOR: acme: fix task allocation leaked upon error
    - CI: github: fix tag listing by implementing proper API pagination
    - BUG/MINOR: quic: close conn on packet reception with incompatible frame
    - BUG/MINOR: stconn: Always declare the SC created from healthchecks as a back SC
    - MINOR: stconn: flag the stream endpoint descriptor when the app has started
    - MINOR: mux-h2: report glitches on early RST_STREAM
    - SCRIPTS: git-show-backports: list new commits and how to review them with -L
    - BUG/MEDIUM: ssl/cli: tls-keys commands warn when accessed without admin level
    - BUG/MEDIUM: ssl/ocsp: ocsp commands warn when accessed without admin level
    - BUG/MEDIUM: map/cli: map/acl commands warn when accessed without admin level
    - BUG/MEDIUM: mux-h1: Don't set MSG_MORE on bodyless responses forwarded to client
    - BUG/MINOR: tcpcheck: Remove unexpected flag on tcpcheck rules for httchck option
    - BUG/MINOR: tcpcheck: Don't enable http_needed when parsing HTTP samples
    - BUG/MINOR: tcpcheck: Use tcpcheck context for expressions parsing
    - BUG/MINOR: quic: fix documentation for transport params decoding
    - BUG/MINOR: cfgcond: properly set the error pointer on evaluation error
    - BUG/MINOR: cfgcond: always set the error string on openssl_version checks
    - BUG/MINOR: cfgcond: fail cleanly on missing argument for "feature"
    - DOC: config: fix ambiguous info in log-steps directive description
    - BUG/MEDIUM: mux-h1: Disable 0-copy forwarding when draining the request
    - BUG/MINOR: http-act: fix a typo in the "pause" action error message
    - BUG/MEDIUM: payload: validate SNI name_len in req.ssl_sni
    - BUG/MEDIUM: jwt: fix heap overflow in ECDSA signature DER conversion
    - BUG: hlua: fix stack overflow in httpclient headers conversion
    - BUG/MINOR: hlua: fix stack overflow in httpclient headers conversion
    - BUG/MINOR: hlua: fix format-string vulnerability in Patref error path
    - BUG/MINOR: peers: fix OOB heap write in dictionary cache update
    - BUG/MAJOR: slz: always make sure to limit fixed output to less than worst case literals
    - BUG/MINOR: resolvers: fix memory leak on AAAA additional records
    - BUG/MINOR: spoe: fix pointer arithmetic overflow in spoe_decode_buffer()
    - BUG/MEDIUM: samples: Fix handling of SMP_T_METH samples
    - BUG/MINOR: sample: fix info leak in regsub when exp_replace fails
    - BUG/MEDIUM: mux-fcgi: prevent record-length truncation with large bufsize
    - BUG/MINOR: hlua: fix use-after-free of HTTP reason string
    - BUG/MINOR: ot: fixed wrong NULL check in flt_ot_parse_cfg_group()
    - BUG/MINOR: log: Fix error message when using unavailable fetch in logfmt
    - BUG/MEDIUM: cli: Properly handle too big payload on a command line
    - BUG/MEDIUM: htx: Fix function used to change part of a block value when defrag
    - BUG/MEDIUM: htx: Don't count delta twice when block value is replaced
    - BUG/MINOR: acme: don't pass NULL into format string
    - BUG/MEDIUM: peers: trash of expired entries delayed after fullresync
    - BUG/MEDIUM: mux-h2: ignore conn->owner when deciding if a connection is dead
    - BUG/MINOR: task: fix uninitialised read in run_tasks_from_lists()
    - BUG/MINOR: log: consider format expression dependencies to decide when to log
    - MINOR: sample: make RQ/RS stats available everywhere
    - BUG/MINOR: sample: adjust dependencies for channel output bytes counters
    - BUG/MAJOR: sched: protect task->expire on 32-bit platforms
    - reg-tests/ssl/ssl_dh.vtc: fix syntax error
    - REGTESTS: ssl: mark ssl_dh.vtc as broken
    - BUG/MINOR: mux-h2: count a protocol error when failing to parse a trailer
    - BUG/MINOR: mux-h2: count a proto error when rejecting a stream on parsing error
    - BUG/MEDIUM: tasks: Make sure we don't schedule a task already running
    - BUG/MINOR: h2: make tune.h2.log-errors actually work
    - BUG/MINOR: h2: Don't look at the exclusive bit for PRIORITY frame
    - BUG/MINOR: H2: Don't forget to free shared_rx_bufs on failure
    - BUG/MINOR: log: also wait for the response when logging response headers
    - BUG/MINOR: mux-h1: Fix condition to send null-chunk for bodyless message
    - BUG/MINOR: mux-h1: Fix test to skip trailers from chunked messages
    - REGTESTS: Never reuse server connection in jwt/jws_verify.vtc
    - REGTESTS: Never reuse server connection in server/cli_delete_dynamic_server.vtc
    - SCRIPTS: build-vtest: allow to set a TMPDIR and a DESTDIR
    - CI: VTest build with git clone + cache
    - CI: github: only enable OS X on development branches
    - BUG/MINOR: compression: properly disable request when setting response
    - BUG/MINOR: debug: properly mark the entire libs archive read-only
    - BUG/MAJOR: mux-h2: detect incomplete transfers on HEADERS frames as well
    - BUG/MEDIUM: mux-h1: Force close mode for bodyless message announcing a C-L

2026/03/19 : 3.2.15
    - BUG/MINOR: mworker: don't set the PROC_O_LEAVING flag on master process
    - BUG/MINOR: tcpcheck: Fix typo in error error message for `http-check expect`
    - BUG/MINOR: jws: fix memory leak in jws_b64_signature
    - DOC: configuration: http-check expect example typo
    - DOC/CLEANUP: config: update mentions of the old "Global parameters" section
    - BUG/MINOR: mworker: always stop the receiving listener
    - BUG/MINOR: memprof: avoid a small memory leak in "show profiling"
    - MINOR: tools: extend the pointer hashing code to ease manipulations
    - MINOR: memprof: attempt different retry slots for different hashes on collision
    - BUG/MINOR: mworker: only match worker processes when looking for unspawned proc
    - BUG/MINOR: mworker: fix typo &= instead of & in proc list serialization
    - BUG/MINOR: mworker: set a timeout on the worker socketpair read at startup
    - BUG/MINOR: mworker: avoid passing NULL version in proc list serialization
    - BUG/MINOR: sockpair: set FD_CLOEXEC on fd received via SCM_RIGHTS
    - BUG/MINOR: spoe: Properly switch SPOE filter to WAITING_ACK state
    - BUG/MEDIUM: spoe: Properly abort processing on client abort
    - BUG/MINOR: h2/h3: Only test number of trailers inserted in HTX message
    - MINOR: htx: Add function to truncate all blocks after a specific block
    - BUG/MINOR: h2/h3: Never insert partial headers/trailers in an HTX message
    - BUG/MINOR: http-ana: Swap L7 buffer with request buffer by hand
    - BUG/MINOR: proxy: do not forget to validate quic-initial rules
    - BUG/MINOR: stream: Fix crash in stream dump if the current rule has no keyword
    - BUG/MINOR: mjson: make mystrtod() length-aware to prevent out-of-bounds reads
    - BUG/MINOR: spoe: Fix condition to abort processing on client abort
    - BUILD: spoe: Remove unsused variable
    - DEV: gdb: add a utility to find the post-mortem address from a core
    - MINOR: tools: add a function to create a tar file header
    - MINOR: tools: add a function to load a file into a tar archive
    - MINOR: config: support explicit "on" and "off" for "set-dumpable"
    - MINOR: debug: read all libs in memory when set-dumpable=libs
    - DEV: gdb: add a new utility to extract libs from a core dump: libs-from-core
    - MINOR: debug: copy debug symbols from /usr/lib/debug when present
    - MINOR: debug: opportunistically load libthread_db.so.1 with set-dumpable=libs
    - BUG/MINOR: mworker: don't try to access an initializing process
    - BUG/MEDIUM: peers: enforce check on incoming table key type
    - BUG/MINOR: mux-h2: properly ignore R bit in GOAWAY stream ID
    - BUG/MINOR: mux-h2: properly ignore R bit in WINDOW_UPDATE increments
    - BUG/MAJOR: h3: check body size with content-length on empty FIN
    - BUG/MEDIUM: h3: reject unaligned frames except DATA
    - MINOR: mworker/cli: extract worker "show proc" row printer
    - BUG/MINOR: mworker/cli: fix show proc pagination losing entries on resume
    - CI: github: treat vX.Y.Z release tags as stable like haproxy-* branches

2026/03/09 : 3.2.14
    - MINOR: mux-h2: also count glitches on invalid trailers
    - MINOR: mux-h2: add a new setting, "tune.h2.log-errors" to tweak error logging
    - BUG/MEDIUM: mux-h2: make sure to always report pending errors to the stream
    - BUG/MINOR: promex: fix server iteration when last server is deleted
    - BUG/MEDIUM: stream: Handle TASK_WOKEN_RES as a stream event
    - BUG/MEDIUM: hpack: correctly deal with too large decoded numbers
    - BUG/MAJOR: qpack: unchecked length passed to huffman decoder
    - BUG/MINOR: qpack: fix 1-byte OOB read in qpack_decode_fs_pfx()
    - BUG/MEDIUM: qpack: correctly deal with too large decoded numbers
    - BUG/MINOR: h1-htx: Be sure that H1 response version starts by "HTTP/"
    - DEBUG: stream: Display the currently running rule in stream dump
    - MINOR: filters: Set last_entity when a filter fails on stream_start callback
    - BUG/MAJOR: fcgi: Fix param decoding by properly checking its size
    - BUG/MAJOR: resolvers: Properly lowered the names found in DNS response
    - BUG/MEDIUM: mux-fcgi: Use a safe loop to resume each stream eligible for sending
    - BUG/MINOR: ssl-sample: Fix sample_conv_sha2() by checking EVP_Digest* failures
    - BUG/MINOR: backend: Don't get proto to use for webscoket if there is no server
    - SCRIPTS: git-show-backports: hide the common ancestor warning in quiet mode
    - SCRIPTS: git-show-backports: add a restart-from-last option


```

</details>