### PR TITLE
Bump haproxy version to 3.2.17

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.16.tar.gz:
-  size: 5147998
-  object_id: bccfcb21-02a3-457a-5c19-7031edb8b38d
-  sha: sha256:2ed807f2a8742a4c1ec64906fe857bc53472d521aea8dcc453c82b8e5b1ecb02
+haproxy/haproxy-3.2.17.tar.gz:
+  size: 5148495
+  object_id: 3418723b-b3d7-4272-4222-e51fd502a05e
+  sha: sha256:023a9efb8a8d73a0c1b6335394400e7eeb4ad0643ffda73c5f93820a720a9695
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.1  # http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz
 
-HAPROXY_VERSION=3.2.16  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.16.tar.gz
+HAPROXY_VERSION=3.2.17  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.17.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.16 to version 3.2.17, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.17.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.17](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.17](https://www.haproxy.org/bugs/bugs-3.2.17.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.17 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.17%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.17 and 3.2.16</summary>

```
2026/04/30 : 3.2.17
    - BUG/MINOR: tcpcheck: Allow connection reuse without prior traffic
    - BUG/MINOR: ssl: fix memory leaks on realloc failure in ssl_ckch.c
    - DOC: config: Fix log-format example with last rule expressions
    - BUG/MINOR: tools: my_memspn/my_memcspn wrong cast causing incorrect byte reading
    - BUG/MINOR: tools: fix memory leak in indent_msg() on out of memory
    - BUG/MINOR: tools: free previously allocated strings on strdup failure in backup_env()
    - BUG/MINOR: sample: fix memory leak in check_when_cond() when ACL is not found
    - BUG/MINOR: sample: fix NULL strm dereference in sample_conv_when
    - BUG/MINOR: peers: fix logical "and" when checking for local in PEER_APP_ST_STARTING
    - BUG/MINOR: peers: fix wrong flag reported twice for dump_flags
    - BUG/MEDIUM: mux_h1: fix stack buffer overflow in h1_append_chunk_size()
    - BUG/MINOR: http_ana: use scf to report term_evts in http_wait_for_request()
    - BUILD: 51d: fix bool definition on dummy lib v4
    - BUG/MAJOR: http-htx: Store new host in a chunk for scheme-based normalization
    - BUG/MEDIUM: http-htx: Don't use data from HTX message to update authority
    - BUG/MEDIUM: http-htx: Loop on full host value during scheme based normalization
    - BUG/MAJOR: mux-h1: Deal with true 64-bits integer to emit chunks size
    - BUG/MEDIUM: tasks: Do not loop in task_schedule() if a task is running
    - BUG/MINOR: fix various typos and spelling mistakes in user-visible messages
    - BUG/MINOR: payload: validate minimum keyshare_len in smp_fetch_ssl_keyshare_groups
    - BUG/MINOR: payload: prevent integer overflow in distcc token parsing
    - BUG/MEDIUM: mux-fcgi: Properly handle full buffer for FCGI_PARAM record
    - BUG/MINOR: http-htx: Don't normalize emtpy path for OPTIONS requests
    - BUG/MEDIUM: acme: fix segfault on newOrder with empty authorizations
    - BUG/MINOR: acme: skip auth/challenge steps when newOrder returns a certificate


```

</details>