### PR TITLE
Bump haproxy version to 3.2.18

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-3.2.17.tar.gz:
-  size: 5148495
-  object_id: 3418723b-b3d7-4272-4222-e51fd502a05e
-  sha: sha256:023a9efb8a8d73a0c1b6335394400e7eeb4ad0643ffda73c5f93820a720a9695
+haproxy/haproxy-3.2.18.tar.gz:
+  size: 5153122
+  object_id: 3d3708bf-ef16-4a18-40d6-6b59b136f35f
+  sha: sha256:da8c1486d418e11188febbbb90a3a64690ed9e5c882c711b688b82fd4907143c
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.47  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.8.1.1  # http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz
 
-HAPROXY_VERSION=3.2.17  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.17.tar.gz
+HAPROXY_VERSION=3.2.18  # https://www.haproxy.org/download/3.2/src/haproxy-3.2.18.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 3.2.17 to version 3.2.18, downloaded from https://www.haproxy.org/download/3.2/src/haproxy-3.2.18.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.

[Changelog for HAProxy 3.2.18](https://www.haproxy.org/download/3.2/src/CHANGELOG).

Please also check list of [known open bugs for HAProxy 3.2.18](https://www.haproxy.org/bugs/bugs-3.2.18.html).

The developer's summary for this release can be found in [the Announcement post for the HAProxy 3.2.18 release](https://www.mail-archive.com/search?l=haproxy%40formilux.org&q=announce+subject%3A%22[ANNOUNCE]+haproxy-3.2.18%22+-subject%3A%22re:%22).

<details>

<summary>HAPROXY CHANGELOG between 3.2.18 and 3.2.17</summary>

```
2026/05/06 : 3.2.18
    - BUG/MINOR: sink: do not free existing sinks on allocation error
    - BUG/MINOR: vars: make parse_store() return error on var_set() failure
    - BUG/MINOR: vars: don't store the variable twice with set-var-fmt
    - BUG/MINOR: vars: only print first invalid char in fill_desc()
    - BUG/MINOR: hpack: validate idx > 0 in hpack_valid_idx()
    - BUG/MEDIUM: cli: fix master CLI connection slot leak on client disconnect
    - BUG/MINOR: acl: fix a possible arg corruption in smp_fetch_acl_parse()
    - BUG/MINOR: map: do not leak a map descriptor on load error
    - CLEANUP: map/cli: fix some map-related help messages
    - BUG/MINOR: pattern: release the reference on failure to load from file
    - BUG/MEDIUM: mux-h2: fix the body_len to check when parsing request trailers
    - BUG/MAJOR: mux-h2: preset MSGF_BODY_CL on H2_SF_DATA_CLEN in h2c_dec_hdrs()
    - BUG/MINOR: dns: always validate the source address in responses
    - BUG/MINOR: tcpcheck: Properly report error for http health-checks
    - BUG/MINOR: resolvers: Free new requester on error when linking a resolution
    - BUG/MINOR: resolvers: Free opts on parse error in resolv_parse_do_resolve()
    - REGTESTS: add a regtest to validate various NTLM transitions
    - BUG/MEDIUM: mworker/cli: fix user and operator permission via @@<pid> in master CLI
    - BUG/MINOR: mworker/cli: check ci_insert() return value in pcli_parse_request()
    - DOC: acme: document missing acme-vars and provider-name keywords
    - REGTESTS: http-messaging: always send RFC8441 client settings to use ext connect
    - BUG/MINOR: h2: add decoding for :protocol in traces
    - BUG/MINOR: mux-h2: condition the processing of 8441 extension to global setting
    - MINOR: mux-h2: add a new message flag to indicate ext connect support
    - BUG/MINOR: h2: only accept :protocol with extended CONNECT
    - BUG/MINOR: acme: contact mail should be optional, don't pass ToS bool
    - BUG/MINOR: http-fetch: Fix http_auth_bearer() when custom header is used
    - BUG/MEDIUM: h1_htx: Remove reverved block on error during contig chunks parsing
    - BUG/MINOR: tools: read_line_to_trash() handle empty files without \n
    - BUG/MAJOR: http: forbid comma character in authority value
    - BUG/MEDIUM: h1: Enforce the authority validation during H1 request parsing


```

</details>