### PR TITLE
fix: pinned docker-cpi version

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cloudfoundry/bosh/docker-cpi:latest
+FROM ghcr.io/cloudfoundry/bosh/docker-cpi@sha256:1ce361cdc6a26b6382a542b889da8bd56c28220065c5185bf6e7bdd21f4a8931
 
 # Install all necessary tools for haproxy testflight and dependency autobump
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -25,6 +25,7 @@ jobs:
       - get: git
         trigger: true
       - get: haproxy-boshrelease-testflight
+        trigger: true
       - task: lint
         image: haproxy-boshrelease-testflight
         config:
@@ -125,7 +126,7 @@ jobs:
         - { get: git, trigger: true, passed: [unit-tests] }
         - { get: stemcell }
         - { get: stemcell-jammy }
-        - get: haproxy-boshrelease-testflight
+        - { get: haproxy-boshrelease-testflight, trigger: true, passed: [build-haproxy-testflight-image] }
       - task: acceptance-tests
         privileged: true
         timeout: 4h
@@ -377,7 +378,7 @@ jobs:
     plan:
       - in_parallel:
           - { get: git-pull-requests, trigger: true, version: every }
-          - get: docker-cpi-image
+          - { get: docker-cpi-image, trigger: true }
       - task: create-pr-tag
         image: docker-cpi-image
         config:
@@ -486,9 +487,11 @@ resources:
       interval: 24h
 
   - name: docker-cpi-image
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/cloudfoundry/bosh/docker-cpi
+    version:
+      digest: "sha256:1ce361cdc6a26b6382a542b889da8bd56c28220065c5185bf6e7bdd21f4a8931"
 
   - name: git-ci
     type: git


### PR DESCRIPTION
## Summary

1. Pinned the Docker-CPI image to the workable version (Bosh v282.1.13).
- This image is currently actively developed, and periodically, some bugs and/or breaking changes are introduced, causing the acceptance tests to fail. The bugs are fixed in future versions, but in the meantime, we are blocked.
- Previously, we always used the image with the tag `latest`. Unfortunately, there are no release-like tags with stable versions, so I have chosen the latest version that passed the tests.
2. Changed resource type for Docker CPI to `registry-image`.
- The resource type `docker-image` does not support pulling images by digest. 
3. Added the missed triggers to automatically rerun tests when the haproxy-boshrelease image changes.