### PR TITLE
fix: Adapt the download link for keepalived

### DIFF
--- a/ci/scripts/autobump-dependencies.py
+++ b/ci/scripts/autobump-dependencies.py
@@ -279,7 +279,7 @@ class GithubDependency(Dependency):
             if latest_version < current_version and current_raw.startswith(self.pinned_version):
                 latest_version = current_version
                 latest_release = Release(
-                    rel.title,
+                    rel.name,
                     get_release_download_url(rel),
                     f"{self.name}-{str(current_version)}{self.filename_suffix}",
                     current_version,
@@ -462,9 +462,8 @@ def main() -> None:
             "keepalived",
             "KEEPALIVED_VERSION",
             KEEPALIVED_VERSION,
-            "https://keepalived.org/download.html",
+            "https://keepalived.org/download",
             package="keepalived",
-            selector="div.content a",
             changelog_url="https://keepalived.org/release-notes/"
         ),
         WebLinkDependency(


### PR DESCRIPTION
Currently, [autobump-dependency concourse job](https://concourse.arp.cloudfoundry.org/teams/main/pipelines/haproxy-boshrelease/jobs/autobump-dependencies/builds/607) is failing due to:
```
Exception: Failed to get the latest keepalived version from https://keepalived.org/download.html
```

This PR adapts the download URL for the keepalived release and fixes the warning `DeprecationWarning: Use name instead
rel.title`