### PR TITLE
fix ci: do not trigger build image on every new docker-cpi-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -378,7 +378,7 @@ jobs:
     plan:
       - in_parallel:
           - { get: git-pull-requests, trigger: true, version: every }
-          - { get: docker-cpi-image, trigger: true }
+          - { get: docker-cpi-image }
       - task: create-pr-tag
         image: docker-cpi-image
         config:


### PR DESCRIPTION
The concourse unit-test-pr job is sometimes not triggered on PR changes (or newly created PRs) because of dependency on `build-haproxy-testflight-image-pr`. 

**Solution provided in this PR:** It is not necessary to trigger `build-haproxy-testflight-image-pr` on every docker-cpi-image; only create a new `haproxy-testflight` image on new commits in open PRs. 